### PR TITLE
Field rejection

### DIFF
--- a/hawaii-core/src/main/java/org/hawaiiframework/validation/ValidationResult.java
+++ b/hawaii-core/src/main/java/org/hawaiiframework/validation/ValidationResult.java
@@ -147,21 +147,25 @@ public class ValidationResult {
         }
     }
 
-    public void rejectValueIf(boolean expr, String field, String code) {
-        if (expr) {
-            rejectValue(field, code);
-        }
+    /**
+     * Reject a <code>field</code> with value <code>actual</code> in a fluent manner.
+     *
+     * For instance:
+     * <blockquote>
+     *     validationResult.rejectField("houseNumber", "13-a")
+     *                          .whenNull()
+     *                          .orWhen(containsString("a"))
+     *                          .orWhen(h -> h.length() > 4);
+     * </blockquote>
+     *
+     * @param field The field name to evaluate.
+     * @param actual The value to evaluate.
+     * @param <T> The type of the value.
+     * @return a new field rejection.
+     */
+    public <T> FieldRejection<T> rejectField(String field, T actual) {
+        return new FieldRejection(this, field, actual);
     }
-
-    public <T> void rejectValueIf(T actual, Matcher<? super T> matcher, String field, String code) {
-        rejectValueIf(matcher.matches(actual), field, code);
-    }
-
-
-    public <T> FieldRejection<T> rejectField(String code, T actual) {
-        return new FieldRejection(this, code, actual);
-    }
-
 
     /**
      * Adds the supplied {@link ValidationError} to this {@link ValidationResult}.

--- a/hawaii-core/src/main/java/org/hawaiiframework/validation/ValidationResult.java
+++ b/hawaii-core/src/main/java/org/hawaiiframework/validation/ValidationResult.java
@@ -19,6 +19,7 @@ package org.hawaiiframework.validation;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hamcrest.Matcher;
+import org.hawaiiframework.validation.field.FieldRejection;
 
 import java.util.*;
 
@@ -155,6 +156,12 @@ public class ValidationResult {
     public <T> void rejectValueIf(T actual, Matcher<? super T> matcher, String field, String code) {
         rejectValueIf(matcher.matches(actual), field, code);
     }
+
+
+    public <T> FieldRejection<T> rejectField(String code, T actual) {
+        return new FieldRejection(this, code, actual);
+    }
+
 
     /**
      * Adds the supplied {@link ValidationError} to this {@link ValidationResult}.

--- a/hawaii-core/src/main/java/org/hawaiiframework/validation/field/FieldRejection.java
+++ b/hawaii-core/src/main/java/org/hawaiiframework/validation/field/FieldRejection.java
@@ -1,43 +1,331 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.hawaiiframework.validation.field;
 
 import org.hamcrest.Matcher;
 import org.hawaiiframework.validation.ValidationResult;
 
-import static org.hamcrest.Matchers.nullValue;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Reject a field based on a few conditions.
+ *
+ * For instance
+ * <blockquote>
+ *     new FieldRejection(validationResult, "houseNumber", "13-a")
+ *              .whenNull()
+ *              .orWhen(h -> h.contains("a"))
+ *              .orWhen(h -> h.length() > 10);
+ * </blockquote>
+ *
+ * If used with the ValidationResult class this will look like:
+ * <blockquote>
+ *     validationResult.rejectField("houseNumber", "13-a")
+ *              .whenNull()
+ *              .orWhen(h -> h.contains("a'))
+ *              .orWhen(h -> h.length() > 10);
+ * </blockquote>
+ *
+ * The rejections without <code>code</code> parameters have the value <literal>invalid</literal>, except the
+ * <code>whenNull()</code>, this has the <literal>required</literal> code value.
+ *
+ * The chain will stop evaluating the rejection clauses after the first matching clause. In the examples above
+ * the chain will not evaluate the length of the house number.
+ *
+ * @author Rutger Lubbers
+ *
+ * @param <T> The type of the value to evaluate.
+ */
 public class FieldRejection<T> {
 
+    public static final String REQUIRED = "required";
+    public static final String INVALID = "invalid";
     private final ValidationResult validationResult;
     private final String field;
     private final T actual;
 
-    private boolean rejected = false;
+    private boolean mustEvaluate = true;
 
+    /**
+     * Construct a new field rejection.
+     *
+     * @param validationResult The validation result.
+     * @param field The field name (property name).
+     * @param actual The field's value.
+     */
     public FieldRejection(final ValidationResult validationResult, final String field, final T actual) {
         this.validationResult = validationResult;
         this.field = field;
         this.actual = actual;
     }
 
-    public FieldRejection<T> when(final Matcher<T> matcher) {
-        return when(matcher, "invalid");
-    }
-
-    public FieldRejection<T> when(final Matcher<T> matcher, final String code) {
-        if (!rejected) {
+    private FieldRejection<T> _when(final Matcher<?> matcher, final String code) {
+        if (mustEvaluate) {
             if (matcher.matches(actual)) {
-                rejected = true;
+                mustEvaluate = false;
                 validationResult.rejectValue(field, code);
             }
         }
+
         return this;
     }
 
-    public FieldRejection<T> ifNull() {
-        return ifNull("required");
+    /**
+     * Syntactic sugar, allows the use of <code>or().when(...).or().when(...)</code> syntaxis.
+     *
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> or() {
+        return this;
     }
 
-    public FieldRejection<T> ifNull(final String code) {
-        return when(nullValue(), code);
+    /**
+     * Rejects the field when the <code>actual</code> is <literal>null</literal>. This will reject the field with the error
+     * code <literal>required</literal>.
+     *
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> whenNull() {
+        return whenNull(REQUIRED);
     }
+
+    /**
+     * Rejects the field when the <code>actual</code> is <literal>null</literal>. This will reject the field
+     * with supplied the error code <code>code</code>.
+     *
+     * @param code The error code to set if the actual value is <literal>null</literal>.
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> whenNull(final String code) {
+        return _when(nullValue(), code);
+    }
+
+    /**
+     * Rejects the field when the <code>matcher</code> matches the <code>actual</code> value. This will reject the field with the error
+     * code <literal>invalid</literal>.
+     *
+     * @param matcher The matcher to use.
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> or(final Matcher<T> matcher) {
+        return when(matcher);
+    }
+
+    /**
+     * Rejects the field when the <code>matcher</code> matches the <code>actual</code> value. This will reject the field with the error
+     * code <literal>invalid</literal>.
+     *
+     * @param matcher The matcher to use.
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> orWhen(final Matcher<T> matcher) {
+        return when(matcher);
+    }
+
+    /**
+     * Rejects the field when the <code>matcher</code> matches the <code>actual</code> value. This will reject the field with the error
+     * code <literal>invalid</literal>.
+     *
+     * @param matcher The matcher to use.
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> when(final Matcher<T> matcher) {
+        return when(matcher, INVALID);
+    }
+
+    /**
+     * Rejects the field when the <code>matcher</code> matches the <code>actual</code> value. This will reject the field
+     * with supplied the error code <code>code</code>.
+     *
+     * @param matcher The matcher to use.
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> or(final Matcher<T> matcher, final String code) {
+        return when(matcher, code);
+    }
+
+    /**
+     * Rejects the field when the <code>matcher</code> matches the <code>actual</code> value. This will reject the field
+     * with supplied the error code <code>code</code>.
+     *
+     * @param matcher The matcher to use.
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> orWhen(final Matcher<T> matcher, final String code) {
+        return when(matcher, code);
+    }
+
+    /**
+     * Rejects the field when the <code>matcher</code> matches the <code>actual</code> value. This will reject the field
+     * with supplied the error code <code>code</code>.
+     *
+     * @param matcher The matcher to use.
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> when(final Matcher<T> matcher, final String code) {
+        return _when(matcher, code);
+    }
+
+    /**
+     * Rejects the field when the <code>predicate</code> evaluates to <literal>true</literal>. This will reject the field with the error
+     * code <literal>invalid</literal>.
+     *
+     * @param predicate The predicate to use.
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> or(final Predicate<T> predicate) {
+        return when(predicate);
+    }
+
+    /**
+     * Rejects the field when the <code>predicate</code> evaluates to <literal>true</literal>. This will reject the field with the error
+     * code <literal>invalid</literal>.
+     *
+     * @param predicate The predicate to use.
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> orWhen(final Predicate<T> predicate) {
+        return when(predicate);
+    }
+
+    /**
+     * Rejects the field when the <code>predicate</code> evaluates to <literal>true</literal>. This will reject the field with the error
+     * code <literal>invalid</literal>.
+     *
+     * @param predicate The predicate to use.
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> when(final Predicate<T> predicate) {
+        return when(predicate, INVALID);
+    }
+
+    /**
+     * Rejects the field when the <code>predicate</code> evaluates to <literal>true</literal>. This will reject the field
+     * with supplied the error code <code>code</code>.
+     *
+     * @param predicate The predicate to use.
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> or(final Predicate<T> predicate, final String code) {
+        return when(predicate, code);
+    }
+
+    /**
+     * Rejects the field when the <code>predicate</code> evaluates to <literal>true</literal>. This will reject the field
+     * with supplied the error code <code>code</code>.
+     *
+     * @param predicate The predicate to use.
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> orWhen(final Predicate<T> predicate, final String code) {
+        return when(predicate, code);
+    }
+
+    /**
+     * Rejects the field when the <code>predicate</code> evaluates to <literal>true</literal>. This will reject the field
+     * with supplied the error code <code>code</code>.
+     *
+     * @param predicate The predicate to use.
+     * @return The current field rejection.
+     */
+    public FieldRejection<T> when(final Predicate<T> predicate, final String code) {
+        if (mustEvaluate) {
+            if (predicate.test(actual)) {
+                mustEvaluate = false;
+                validationResult.rejectValue(field, code);
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * Rejects the field when the <code>matcher</code> matches the result of the <code>function</code>.
+     * This will reject the field with the error code <literal>invalid</literal>.
+     *
+     * @param function The function to apply to the <code>actual</code> value.
+     * @param matcher The matcher to use against the return value of the <code>function</code>.
+     * @return The current field rejection.
+     */
+    public <R> FieldRejection<T> or(Function<T, R> function, final Matcher<R> matcher) {
+        return when(function, matcher, INVALID);
+    }
+
+    /**
+     * Rejects the field when the <code>matcher</code> matches the result of the <code>function</code>.
+     * This will reject the field with the error code <literal>invalid</literal>.
+     *
+     * @param function The function to apply to the <code>actual</code> value.
+     * @param matcher The matcher to use against the return value of the <code>function</code>.
+     * @return The current field rejection.
+     */
+    public <R> FieldRejection<T> orWhen(Function<T, R> function, final Matcher<R> matcher) {
+        return when(function, matcher, INVALID);
+    }
+
+    /**
+     * Rejects the field when the <code>matcher</code> matches the result of the <code>function</code>.
+     * This will reject the field with the error code <literal>invalid</literal>.
+     *
+     * @param function The function to apply to the <code>actual</code> value.
+     * @param matcher The matcher to use against the return value of the <code>function</code>.
+     * @return The current field rejection.
+     */
+    public <R> FieldRejection<T> when(Function<T, R> function, final Matcher<R> matcher) {
+        return when(function, matcher, INVALID);
+    }
+
+    /**
+     * Rejects the field when the <code>matcher</code> matches the result of the <code>function</code>.
+     * This will reject the field with supplied the error code <code>code</code>.
+     *
+     * @param function The function to apply to the <code>actual</code> value.
+     * @param matcher The matcher to use against the return value of the <code>function</code>.
+     * @return The current field rejection.
+     */
+    public <R> FieldRejection<T> or(Function<T, R> function, final Matcher<R> matcher, final String code) {
+        return when(function, matcher, code);
+    }
+
+    /**
+     * Rejects the field when the <code>matcher</code> matches the result of the <code>function</code>.
+     * This will reject the field with supplied the error code <code>code</code>.
+     *
+     * @param function The function to apply to the <code>actual</code> value.
+     * @param matcher The matcher to use against the return value of the <code>function</code>.
+     * @return The current field rejection.
+     */
+    public <R> FieldRejection<T> orWhen(Function<T, R> function, final Matcher<R> matcher, final String code) {
+        return when(function, matcher, code);
+    }
+
+    /**
+     * Rejects the field when the <code>matcher</code> matches the result of the <code>function</code>.
+     * This will reject the field with supplied the error code <code>code</code>.
+     *
+     * @param function The function to apply to the <code>actual</code> value.
+     * @param matcher The matcher to use against the return value of the <code>function</code>.
+     * @return The current field rejection.
+     */
+    public <R> FieldRejection<T> when(Function<T, R> function, final Matcher<R> matcher, final String code) {
+        return when(v -> matcher.matches(function.apply(v)), code);
+    }
+
 }

--- a/hawaii-core/src/main/java/org/hawaiiframework/validation/field/FieldRejection.java
+++ b/hawaii-core/src/main/java/org/hawaiiframework/validation/field/FieldRejection.java
@@ -1,0 +1,43 @@
+package org.hawaiiframework.validation.field;
+
+import org.hamcrest.Matcher;
+import org.hawaiiframework.validation.ValidationResult;
+
+import static org.hamcrest.Matchers.nullValue;
+
+public class FieldRejection<T> {
+
+    private final ValidationResult validationResult;
+    private final String field;
+    private final T actual;
+
+    private boolean rejected = false;
+
+    public FieldRejection(final ValidationResult validationResult, final String field, final T actual) {
+        this.validationResult = validationResult;
+        this.field = field;
+        this.actual = actual;
+    }
+
+    public FieldRejection<T> when(final Matcher<T> matcher) {
+        return when(matcher, "invalid");
+    }
+
+    public FieldRejection<T> when(final Matcher<T> matcher, final String code) {
+        if (!rejected) {
+            if (matcher.matches(actual)) {
+                rejected = true;
+                validationResult.rejectValue(field, code);
+            }
+        }
+        return this;
+    }
+
+    public FieldRejection<T> ifNull() {
+        return ifNull("required");
+    }
+
+    public FieldRejection<T> ifNull(final String code) {
+        return when(nullValue(), code);
+    }
+}

--- a/hawaii-core/src/test/java/org/hawaiiframework/validation/ValidationResultTests.java
+++ b/hawaii-core/src/test/java/org/hawaiiframework/validation/ValidationResultTests.java
@@ -22,8 +22,7 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * Tests for {@link ValidationResult}.

--- a/hawaii-core/src/test/java/org/hawaiiframework/validation/field/FieldRejectionTest.java
+++ b/hawaii-core/src/test/java/org/hawaiiframework/validation/field/FieldRejectionTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawaiiframework.validation.field;
+
+import org.hawaiiframework.validation.ValidationError;
+import org.hawaiiframework.validation.ValidationResult;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link FieldRejection}.
+ *
+ * @author Rutger Lubbers
+ */
+public class FieldRejectionTest {
+    private static final String FIELD_NAME = "some_name";
+
+    private static final String INVALID = "invalid";
+    private static final String REQUIRED = "required";
+
+    private static final String ERR_CODE = "some_error_code";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private ValidationResult validationResult;
+
+    @Before
+    public void setUp() {
+        validationResult = new ValidationResult();
+    }
+
+    @Test
+    public void testRejectNull() {
+        String actual = null;
+        validationResult
+                .rejectField(FIELD_NAME, actual)
+                .whenNull();
+
+        assureErrorHas(FIELD_NAME, REQUIRED);
+    }
+
+    @Test
+    public void testRejectNullWithErrorCode() {
+        String actual = null;
+        validationResult
+                .rejectField(FIELD_NAME, actual)
+                .whenNull(ERR_CODE);
+
+        assureErrorHas(FIELD_NAME, ERR_CODE);
+    }
+
+    @Test
+    public void assureThatEvaluationStopsAfterFirstMatch() {
+        String actual = null;
+        validationResult
+                .rejectField(FIELD_NAME, actual)
+                .whenNull()
+                .orWhen(h -> h==null, ERR_CODE);
+
+        assureErrorHas(FIELD_NAME, REQUIRED);
+    }
+
+    @Test
+    public void testThatOrderDoesMatter() {
+        thrown.expect(NullPointerException.class);
+
+        String actual = null;
+        validationResult
+                .rejectField(FIELD_NAME, actual)
+                .orWhen(String::length, is(greaterThan(10)), ERR_CODE)
+                .or()
+                .whenNull();
+    }
+
+    @Test
+    public void assureThatEvaluationStopsAfterFirstMatchWithExplicitOr() {
+        String actual = null;
+        validationResult
+                .rejectField(FIELD_NAME, actual)
+                .whenNull()
+                .or()
+                .when(h -> h==null, ERR_CODE);
+
+        assureErrorHas(FIELD_NAME, REQUIRED);
+    }
+
+    @Test
+    public void testMatchersWork() {
+        String actual = "Some string containing 'foo'.";
+        validationResult
+                .rejectField(FIELD_NAME, actual)
+                .when(containsString("'bar'"), "error")
+                .or()
+                .when(containsString("'foo'"), ERR_CODE);
+
+        assureErrorHas(FIELD_NAME, ERR_CODE);
+    }
+
+    @Test
+    public void testMatchersWorkWithoutExplicitErrorCode() {
+        String actual = "Some string containing 'foo'.";
+        validationResult
+                .rejectField(FIELD_NAME, actual)
+                .when(containsString("'bar'"), "error")
+                .or()
+                .when(containsString("'foo'"));
+
+        assureErrorHas(FIELD_NAME, INVALID);
+    }
+
+    @Test
+    public void testFunction() {
+        String actual = "Some string containing 'foo'.";
+        validationResult
+                .rejectField(FIELD_NAME, actual)
+                .or(String::length, is(greaterThan(10)), "length");
+
+        assureErrorHas(FIELD_NAME, "length");
+
+    }
+
+    private void assureErrorHas(String field, String code) {
+        ValidationError validationError = validationResult.getErrors().get(0);
+        assertThat(validationError.getField(), is(field));
+        assertThat(validationError.getCode(), is(code));
+    }
+}

--- a/samples/hawaii-recipes/src/main/java/org/hawaiiframework/sample/web/input/RecipeInputValidator.java
+++ b/samples/hawaii-recipes/src/main/java/org/hawaiiframework/sample/web/input/RecipeInputValidator.java
@@ -39,22 +39,17 @@ public class RecipeInputValidator implements Validator<RecipeInput> {
 
     @Override
     public void validate(RecipeInput recipe, ValidationResult validationResult) {
-        if (recipe.getName() == null) {
-            validationResult.rejectValue("name", "required");
-        } else {
-            validationResult.rejectValueIf(recipe.getName().length(), greaterThan(100), "name", "length");
-        }
-        if (recipe.getEmail() == null) {
-            validationResult.rejectValue("email", "required");
-        } else {
-            validationResult.rejectValueIf(recipe.getEmail().length(), greaterThan(100), "email", "length");
+        validationResult.rejectField("name", recipe.getName())
+                .whenNull()
+                .orWhen(n -> n.length() > 100, "length");
+
+        validationResult.rejectField("email", recipe.getEmail())
+                .whenNull()
+                .orWhen(String::length, greaterThan(100), "length");
             // TODO validate email
-        }
-        if (recipe.getDescription() == null) {
-            validationResult.rejectValue("description", "required");
-        } else {
-            validationResult.rejectValueIf(recipe.getDescription().length(), greaterThan(100), "description", "length");
-        }
-        // TODO
+
+        validationResult.rejectField("description", recipe.getDescription())
+                .whenNull()
+                .orWhen(d -> d.length() > 1000, "length");
     }
 }


### PR DESCRIPTION
I wonder whether the following methods from ValidationResult should be marked as deprecated:
- rejectValueIf(boolean expr, String code)
- rejectValueIf(T actual, Matcher<? super T> matcher, String code)
- rejectValue(String field, String code)

The usage of the existing methods without a field name are unclear to me. Should we remove those from the code and create a rejectField(actual) for them?
