### PR TITLE
Async - Allow default @Async annotation.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.0.0.BUILD-SNAPSHOT
+version=3.0.0.M7-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.0.0.M7-SNAPSHOT
+version=3.0.0.BUILD-SNAPSHOT

--- a/hawaii-async/src/main/java/org/hawaiiframework/async/AsyncExecutorConfiguration.java
+++ b/hawaii-async/src/main/java/org/hawaiiframework/async/AsyncExecutorConfiguration.java
@@ -16,37 +16,29 @@
 
 package org.hawaiiframework.async;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import org.hawaiiframework.async.config.AsyncExecutorFactory;
+import org.hawaiiframework.async.config.AsyncExecutorInitializer;
+import org.hawaiiframework.async.config.BeanRegistrar;
+import org.hawaiiframework.async.config.DelegatingExecutorFactory;
 import org.hawaiiframework.async.model.ExecutorConfigurationProperties;
-import org.hawaiiframework.async.model.ExecutorProperties;
-import org.hawaiiframework.async.model.SystemProperties;
-import org.hawaiiframework.async.model.TaskProperties;
-import org.hawaiiframework.exception.HawaiiException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.config.ConstructorArgumentValues;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
-import org.springframework.beans.factory.support.GenericBeanDefinition;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.core.task.TaskExecutor;
-import org.springframework.lang.Nullable;
+import org.springframework.lang.NonNull;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-
-import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 
 /**
  * Configuration class to set up asynchronous executors.
@@ -63,14 +55,18 @@ import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
  * <p>
  * <b>NOTE:</b> each async task <b>MUST</b> be specified in the configuration, otherwise an exception will be raised.
  *
- * @since 2.0.0
- *
  * @author Rutger Lubbers
  * @author Paul Klos
+ * @since 2.0.0
  */
 @Configuration
 @EnableAsync
 public class AsyncExecutorConfiguration implements BeanDefinitionRegistryPostProcessor, AsyncConfigurer, EnvironmentAware {
+
+    /**
+     * Async (task) timeout executor bean name.
+     */
+    public static final String ASYNC_TIMEOUT_EXECUTOR = "asyncTimeoutExecutor";
 
     /**
      * Logger for this class.
@@ -83,11 +79,6 @@ public class AsyncExecutorConfiguration implements BeanDefinitionRegistryPostPro
     private static final String EXECUTOR_CONFIGURATION_PROPERTIES = "executorConfigurationProperties";
 
     /**
-     * Async (task) timeout executor bean name.
-     */
-    private static final String ASYNC_TIMEOUT_EXECUTOR = "asyncTimeoutExecutor";
-
-    /**
      * The configuration properties.
      */
     private ExecutorConfigurationProperties properties;
@@ -96,11 +87,6 @@ public class AsyncExecutorConfiguration implements BeanDefinitionRegistryPostPro
      * Set of executor names defined in the properties.
      */
     private final Set<String> executorNames = new HashSet<>();
-
-    /**
-     * Spring's bean definition registry, cached for later use.
-     */
-    private BeanDefinitionRegistry beanDefinitionRegistry;
 
     /**
      * The default executor.
@@ -117,21 +103,25 @@ public class AsyncExecutorConfiguration implements BeanDefinitionRegistryPostPro
     private AsyncPropertiesLoader asyncPropertiesLoader;
 
     /**
+     * Utility to add beans to Spring's bean definition registry.
+     */
+    private BeanRegistrar registrar;
+
+    /**
      * {@inheritDoc}
      */
     @Override
-    public void postProcessBeanDefinitionRegistry(final BeanDefinitionRegistry registry) throws BeansException {
-        // Just to be sure
-        getProperties();
-        beanDefinitionRegistry = registry;
+    public void postProcessBeanDefinitionRegistry(@NonNull final BeanDefinitionRegistry registry) throws BeansException {
+        LOGGER.trace("Creating beans for async executors.");
+        registrar = new BeanRegistrar(registry);
 
-        createGenericBeanDefinition(registry, EXECUTOR_CONFIGURATION_PROPERTIES, ExecutorConfigurationProperties.class);
+        final ExecutorConfigurationProperties properties = getProperties();
+        registrar.registerBean(EXECUTOR_CONFIGURATION_PROPERTIES, ExecutorConfigurationProperties.class);
 
-        final ConstructorArgumentValues taskExecutorConstructorValues = new ConstructorArgumentValues();
-        taskExecutorConstructorValues.addIndexedArgumentValue(0, properties.getAsyncTimeoutExecutorPoolSize());
-        createGenericBeanDefinition(registry, ASYNC_TIMEOUT_EXECUTOR, ScheduledThreadPoolExecutor.class, taskExecutorConstructorValues);
+        final AsyncExecutorFactory factory = new AsyncExecutorFactory(registrar, properties);
+        factory.createExecutors();
 
-        createExecutors(registry);
+        executorNames.addAll(factory.getExecutorNames());
     }
 
     /**
@@ -140,25 +130,24 @@ public class AsyncExecutorConfiguration implements BeanDefinitionRegistryPostPro
      * <p>Configured method names are aliased to their corresponding executor, such that bean lookup works.</p>
      */
     @Override
-    public void postProcessBeanFactory(final ConfigurableListableBeanFactory beanFactory) throws BeansException {
+    public void postProcessBeanFactory(@NonNull final ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        LOGGER.trace("Initializing beans for async executors.");
         final ExecutorConfigurationProperties properties = getProperties();
-
-        // Is this sane? May be used to get the timeout per call
         beanFactory.initializeBean(properties, EXECUTOR_CONFIGURATION_PROPERTIES);
 
-        final ScheduledThreadPoolExecutor asyncTimeoutExecutor = (ScheduledThreadPoolExecutor) beanFactory.getBean(ASYNC_TIMEOUT_EXECUTOR);
-        asyncTimeoutExecutor.setThreadFactory(new BasicThreadFactory.Builder().namingPattern("async-timeout-%d").daemon(true).build());
-        beanFactory.initializeBean(asyncTimeoutExecutor, ASYNC_TIMEOUT_EXECUTOR);
+        final AsyncExecutorInitializer executorInitializer = new AsyncExecutorInitializer(beanFactory, properties);
+        executorInitializer.initializeExecutors();
+        defaultExecutor = executorInitializer.getDefaultExecutor();
 
-        initializeExecutors(beanFactory);
-
-        createSystems(beanFactory);
+        final DelegatingExecutorFactory delegatingExecutorFactory =
+            new DelegatingExecutorFactory(beanFactory, registrar, properties, executorNames);
+        delegatingExecutorFactory.createDelegatingExecutors();
     }
 
     /**
      * {@inheritDoc}
      *
-     * @return the default executor, as determined from {@link #isDefaultExecutor(ExecutorProperties)}
+     * @return the default executor.
      */
     @Override
     public Executor getAsyncExecutor() {
@@ -176,156 +165,23 @@ public class AsyncExecutorConfiguration implements BeanDefinitionRegistryPostPro
     }
 
     /**
-     * Create a {@link GenericBeanDefinition} of the specified class and register it with the registry.
-     *
-     * @param beanDefinitionRegistry the registry
-     * @param beanName               the bean name
-     * @param clazz                  the bean class
-     */
-    private void createGenericBeanDefinition(
-            final BeanDefinitionRegistry beanDefinitionRegistry,
-            final String beanName,
-            final Class<?> clazz) {
-        createGenericBeanDefinition(beanDefinitionRegistry, beanName, clazz, null);
-    }
-
-    /**
-     * Create a {@link GenericBeanDefinition} of the specified class and register it with the registry.
-     *
-     * @param beanDefinitionRegistry    the registry
-     * @param beanName                  the bean name
-     * @param clazz                     the bean class
-     * @param constructorArgumentValues the constructor arguments.
-     */
-    private void createGenericBeanDefinition(
-            final BeanDefinitionRegistry beanDefinitionRegistry,
-            final String beanName,
-            final Class<?> clazz,
-            @Nullable final ConstructorArgumentValues constructorArgumentValues) {
-        final GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
-        beanDefinition.setBeanClass(clazz);
-        beanDefinition.setAutowireMode(ConfigurableListableBeanFactory.AUTOWIRE_NO);
-        beanDefinition.setDependencyCheck(GenericBeanDefinition.DEPENDENCY_CHECK_NONE);
-        if (constructorArgumentValues != null) {
-            beanDefinition.setConstructorArgumentValues(constructorArgumentValues);
-        }
-
-        beanDefinitionRegistry.registerBeanDefinition(beanName, beanDefinition);
-    }
-
-    /**
      * {@inheritDoc}
      * <p>Use the environment to obtain the location of the configuration file.</p>
      */
     @Override
-    public void setEnvironment(final Environment environment) {
+    public void setEnvironment(@NonNull final Environment environment) {
         setAsyncPropertiesLoader(new AsyncPropertiesLoader(environment.getProperty("hawaii.async.configuration")));
     }
 
     /**
      * Setter for the properties loaded.
-     *
+     * <p>
      * Added for testability.
      *
      * @param asyncPropertiesLoader the loader
      */
     public void setAsyncPropertiesLoader(final AsyncPropertiesLoader asyncPropertiesLoader) {
         this.asyncPropertiesLoader = asyncPropertiesLoader;
-    }
-
-    /**
-     * Create executors from the configured executor properties.
-     *
-     * @param registry the bean definition registry
-     */
-    private void createExecutors(final BeanDefinitionRegistry registry) {
-        for (final ExecutorProperties executorProperties : properties.getExecutors()) {
-            if (!executorNames.add(executorProperties.getName())) {
-                throw new HawaiiException(
-                        String.format("Configuration contained multiple definitions of '%s'.", executorProperties.getName()));
-            }
-
-            LOGGER.info("Registering executor '{}'.", executorProperties);
-            createGenericBeanDefinition(registry, executorProperties.getName(), ThreadPoolTaskExecutor.class);
-        }
-    }
-
-    /**
-     * Create bean aliases for the configured systems.
-     * <p>
-     * For each task in the system an {@link DelegatingExecutor} is created with the relevant executor as its delegate. This is either the
-     * configured executor for the task, or the task's system default executor.
-     * <p>
-     * If neither have a configured executor, no alias is created and the call will default to the default executor.
-     *
-     * @param beanFactory the bean factory
-     */
-    private void createSystems(final ConfigurableListableBeanFactory beanFactory) {
-        for (final SystemProperties systemProperties : properties.getSystems()) {
-            final String systemName = systemProperties.getName();
-
-            // This is the fallback if no executor is defined for a task
-            final String systemExecutor = systemProperties.getDefaultExecutor();
-            if (StringUtils.isNotBlank(systemExecutor) && !executorNames.contains(systemExecutor)) {
-                throw new HawaiiException(
-                        String.format("Executor '%s' of system '%s' is not defined.", systemExecutor, systemName));
-            }
-
-            for (final TaskProperties taskProperties : systemProperties.getTasks()) {
-                final String executorName = taskProperties.getExecutor();
-
-                final String taskName = String.format("%s.%s", systemName, taskProperties.getMethod());
-                if (StringUtils.isNotBlank(executorName)) {
-                    if (!executorNames.contains(executorName)) {
-                        throw new HawaiiException(
-                                String.format("Executor '%s' of task '%s' is not defined.", executorName, taskName));
-                    }
-                    LOGGER.debug("Configuring task '{}' to use executor '{}'.", taskName, executorName);
-                } else {
-                    LOGGER.info("No executor defined for task '{}'. Falling back to default.", taskName, systemExecutor);
-                }
-
-                final String executor = defaultIfBlank(executorName, defaultIfBlank(systemExecutor, properties.getDefaultExecutor()));
-                createTaskExecutorDelegate(beanFactory, taskName, executor);
-            }
-        }
-    }
-
-    private void createTaskExecutorDelegate(
-            final ConfigurableListableBeanFactory beanFactory,
-            final String taskName,
-            final String executor) {
-        final TaskExecutor delegate = (TaskExecutor) beanFactory.getBean(executor);
-        final ConstructorArgumentValues constructorArgumentValues = new ConstructorArgumentValues();
-        constructorArgumentValues.addIndexedArgumentValue(0, delegate);
-        constructorArgumentValues.addIndexedArgumentValue(1, properties);
-        constructorArgumentValues.addIndexedArgumentValue(2, taskName);
-        createGenericBeanDefinition(beanDefinitionRegistry, taskName, DelegatingExecutor.class, constructorArgumentValues);
-    }
-
-    /**
-     * Configure a task executor from its configuration properties.
-     *
-     * @param beanFactory        the bean factory
-     * @param executorProperties the executor properties
-     */
-    private TaskExecutor initializeExecutor(
-            final ConfigurableListableBeanFactory beanFactory,
-            final ExecutorProperties executorProperties) {
-        LOGGER.info("Creating executor '{}'.", executorProperties);
-        final ThreadPoolTaskExecutor taskExecutor = (ThreadPoolTaskExecutor) beanFactory.getBean(executorProperties.getName());
-        taskExecutor.setThreadFactory(null);
-        taskExecutor.setThreadNamePrefix(executorProperties.getName() + "-");
-        taskExecutor.setCorePoolSize(executorProperties.getCorePoolSize());
-        taskExecutor.setMaxPoolSize(executorProperties.getMaxPoolSize());
-        taskExecutor.setQueueCapacity(executorProperties.getMaxPendingRequests());
-        taskExecutor.setKeepAliveSeconds(executorProperties.getKeepAliveTime());
-
-        final ScheduledThreadPoolExecutor timeoutExecutor = (ScheduledThreadPoolExecutor) beanFactory.getBean(ASYNC_TIMEOUT_EXECUTOR);
-        taskExecutor.setTaskDecorator(new AbortableTaskDecorator(taskExecutor, timeoutExecutor));
-
-        taskExecutor.initialize();
-        return taskExecutor;
     }
 
     /**
@@ -339,43 +195,4 @@ public class AsyncExecutorConfiguration implements BeanDefinitionRegistryPostPro
         }
         return properties;
     }
-
-    /**
-     * Initialize all configured executors in the bean factory and determine the default executor.
-     *
-     * @param beanFactory the bean factory
-     */
-    private void initializeExecutors(final ConfigurableListableBeanFactory beanFactory) {
-        for (final ExecutorProperties executorProperties : properties.getExecutors()) {
-            final TaskExecutor executor = initializeExecutor(beanFactory, executorProperties);
-            if (isDefaultExecutor(executorProperties)) {
-                defaultExecutor = executor;
-            }
-        }
-    }
-
-    /**
-     * Match the name from the executor properties to the global default executor name.
-     *
-     * @param executorProperties the executor properties to check
-     * @return true if the names match
-     * @see #isDefaultExecutor(String)
-     */
-    private boolean isDefaultExecutor(final ExecutorProperties executorProperties) {
-        return isDefaultExecutor(executorProperties.getName());
-    }
-
-    /**
-     * Match the executor name to the global default executor name.
-     *
-     * @param executorName the executor name
-     * @return true if the names match
-     */
-    private boolean isDefaultExecutor(final String executorName) {
-        if (StringUtils.isBlank(executorName)) {
-            return false;
-        }
-        return executorName.equals(properties.getDefaultExecutor());
-    }
-
 }

--- a/hawaii-async/src/main/java/org/hawaiiframework/async/config/AsyncExecutorFactory.java
+++ b/hawaii-async/src/main/java/org/hawaiiframework/async/config/AsyncExecutorFactory.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawaiiframework.async.config;
+
+import org.hawaiiframework.async.model.ExecutorConfigurationProperties;
+import org.hawaiiframework.async.model.ExecutorProperties;
+import org.hawaiiframework.exception.HawaiiException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import static org.hawaiiframework.async.AsyncExecutorConfiguration.ASYNC_TIMEOUT_EXECUTOR;
+
+/**
+ * Factory to create executors for the asynchronous execution of methods using the @{@link org.springframework.scheduling.annotation.Async}
+ * annotation.
+ *
+ * This factory creates the executors as defined in the {@cod executors} section in the async configuration.
+ * @author Rutger Lubbers
+ * @author Paul Klos
+ * @since 3.0.0
+ */
+public class AsyncExecutorFactory {
+
+    /**
+     * The logger to use.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsyncExecutorFactory.class);
+
+    /**
+     * Set of executor names defined in the properties.
+     */
+    private final Set<String> executorNames = new HashSet<>();
+
+    private final BeanRegistrar registrar;
+
+    private final ExecutorConfigurationProperties properties;
+
+    /**
+     * The constructor.
+     *
+     * @param registrar  The bean registrar.
+     * @param properties The executor properties.
+     */
+    public AsyncExecutorFactory(final BeanRegistrar registrar, final ExecutorConfigurationProperties properties) {
+        this.registrar = registrar;
+        this.properties = properties;
+    }
+
+    /**
+     * Create executors from the configured executor properties.
+     */
+    public void createExecutors() {
+        final ConstructorArgumentValues taskExecutorConstructorValues = new ConstructorArgumentValues();
+        taskExecutorConstructorValues.addIndexedArgumentValue(0, properties.getAsyncTimeoutExecutorPoolSize());
+        registrar.registerBean(ASYNC_TIMEOUT_EXECUTOR, ScheduledThreadPoolExecutor.class, taskExecutorConstructorValues);
+
+        for (final ExecutorProperties executorProperties : properties.getExecutors()) {
+            if (!executorNames.add(executorProperties.getName())) {
+                throw new HawaiiException(
+                    String.format("Configuration contained multiple definitions of '%s'.", executorProperties.getName()));
+            }
+
+            LOGGER.info("Registering executor '{}'.", executorProperties);
+            registrar.registerBean(executorProperties.getName(), ThreadPoolTaskExecutor.class);
+        }
+    }
+
+    public Set<String> getExecutorNames() {
+        return executorNames;
+    }
+}

--- a/hawaii-async/src/main/java/org/hawaiiframework/async/config/AsyncExecutorInitializer.java
+++ b/hawaii-async/src/main/java/org/hawaiiframework/async/config/AsyncExecutorInitializer.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawaiiframework.async.config;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import org.hawaiiframework.async.AbortableTaskDecorator;
+import org.hawaiiframework.async.DelegatingExecutor;
+import org.hawaiiframework.async.model.ExecutorConfigurationProperties;
+import org.hawaiiframework.async.model.ExecutorProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import static org.hawaiiframework.async.AsyncExecutorConfiguration.ASYNC_TIMEOUT_EXECUTOR;
+
+
+/**
+ * Utility to initialize executors for the asynchronous execution of methods using
+ * the @{@link org.springframework.scheduling.annotation.Async} annotation.
+ *
+ * @author Rutger Lubbers
+ * @author Paul Klos
+ * @since 3.0.0
+ */
+public class AsyncExecutorInitializer {
+
+    /**
+     * The logger to use.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(DelegatingExecutorFactory.class);
+
+    /**
+     * The default executor.
+     * <p>
+     * This is determined from the configuration properties.
+     *
+     * @see AsyncConfigurer
+     */
+    private TaskExecutor defaultExecutor;
+
+    /**
+     * Spring's bean factory.
+     */
+    private final ConfigurableListableBeanFactory beanFactory;
+
+    /**
+     * The executor configuration.
+     */
+    private final ExecutorConfigurationProperties configuration;
+
+    /**
+     * The constructor.
+     *
+     * @param beanFactory   Spring's bean factory.
+     * @param configuration The executor configuration.
+     */
+    public AsyncExecutorInitializer(final ConfigurableListableBeanFactory beanFactory,
+        final ExecutorConfigurationProperties configuration) {
+        this.beanFactory = beanFactory;
+        this.configuration = configuration;
+    }
+
+    /**
+     * Initialize all configured executors in the bean factory and determine the default executor.
+     */
+    public void initializeExecutors() {
+        final ScheduledThreadPoolExecutor asyncTimeoutExecutor =
+            (ScheduledThreadPoolExecutor) beanFactory.getBean(ASYNC_TIMEOUT_EXECUTOR);
+        asyncTimeoutExecutor.setThreadFactory(new BasicThreadFactory.Builder().namingPattern("async-timeout-%d").daemon(true).build());
+        beanFactory.initializeBean(asyncTimeoutExecutor, ASYNC_TIMEOUT_EXECUTOR);
+
+        for (final ExecutorProperties executorConfiguration : configuration.getExecutors()) {
+            final ThreadPoolTaskExecutor executor = initializeExecutor(executorConfiguration, asyncTimeoutExecutor);
+            if (isDefaultExecutor(executorConfiguration)) {
+                registerDefaultExecutor(executor);
+            }
+        }
+    }
+
+    private void registerDefaultExecutor(final ThreadPoolTaskExecutor executor) {
+        defaultExecutor = new DelegatingExecutor(executor, configuration, configuration.getDefaultExecutor());
+    }
+
+    @SuppressWarnings("PMD.CommentRequired")
+    public TaskExecutor getDefaultExecutor() {
+        return defaultExecutor;
+    }
+
+
+    /**
+     * Configure a task executor from its configuration properties.
+     *
+     * @param executorConfiguration the executor's configuration.
+     * @param timeoutExecutor       the timeout executor.
+     */
+    private ThreadPoolTaskExecutor initializeExecutor(final ExecutorProperties executorConfiguration,
+        final ScheduledThreadPoolExecutor timeoutExecutor) {
+        LOGGER.info("Creating executor '{}'.", executorConfiguration);
+        final ThreadPoolTaskExecutor taskExecutor = (ThreadPoolTaskExecutor) beanFactory.getBean(executorConfiguration.getName());
+        taskExecutor.setThreadFactory(null);
+        taskExecutor.setThreadNamePrefix(executorConfiguration.getName() + "-");
+        taskExecutor.setCorePoolSize(executorConfiguration.getCorePoolSize());
+        taskExecutor.setMaxPoolSize(executorConfiguration.getMaxPoolSize());
+        taskExecutor.setQueueCapacity(executorConfiguration.getMaxPendingRequests());
+        taskExecutor.setKeepAliveSeconds(executorConfiguration.getKeepAliveTime());
+
+        taskExecutor.setTaskDecorator(new AbortableTaskDecorator(taskExecutor, timeoutExecutor));
+
+        taskExecutor.initialize();
+        return taskExecutor;
+    }
+
+    /**
+     * Match the name from the executor properties to the global default executor name.
+     *
+     * @param executorProperties the executor properties to check
+     * @return true if the names match
+     * @see #isDefaultExecutor(String)
+     */
+    private boolean isDefaultExecutor(final ExecutorProperties executorProperties) {
+        return isDefaultExecutor(executorProperties.getName());
+    }
+
+    /**
+     * Match the executor name to the global default executor name.
+     *
+     * @param executorName the executor name
+     * @return true if the names match
+     */
+    private boolean isDefaultExecutor(final String executorName) {
+        if (StringUtils.isBlank(executorName)) {
+            return false;
+        }
+        return executorName.equals(configuration.getDefaultExecutor());
+    }
+}

--- a/hawaii-async/src/main/java/org/hawaiiframework/async/config/BeanRegistrar.java
+++ b/hawaii-async/src/main/java/org/hawaiiframework/async/config/BeanRegistrar.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawaiiframework.async.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.lang.Nullable;
+
+/**
+ * Utility to add beans to Spring's bean definition registry.
+ *
+ * @author Rutger Lubbers
+ * @author Paul Klos
+ * @since 3.0.0
+ */
+public class BeanRegistrar {
+
+    /**
+     * The logger to use.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(BeanRegistrar.class);
+
+    /**
+     * Spring's bean definition registry.
+     */
+    private final BeanDefinitionRegistry registry;
+
+    /**
+     * The constructor.
+     *
+     * @param registry Spring's bean definition registry.
+     */
+    public BeanRegistrar(final BeanDefinitionRegistry registry) {
+        this.registry = registry;
+    }
+
+    /**
+     * Create a {@link GenericBeanDefinition} of the specified class and register it with the registry.
+     *
+     * @param beanName the bean name
+     * @param clazz    the bean class
+     */
+    public void registerBean(
+        final String beanName,
+        final Class<?> clazz) {
+        registerBean(beanName, clazz, null);
+    }
+
+    /**
+     * Create a {@link GenericBeanDefinition} of the specified class and register it with the registry.
+     *
+     * @param beanName                  the bean name
+     * @param clazz                     the bean class
+     * @param constructorArgumentValues the constructor arguments.
+     */
+    public void registerBean(
+        final String beanName,
+        final Class<?> clazz,
+        @Nullable final ConstructorArgumentValues constructorArgumentValues) {
+        final GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
+        beanDefinition.setBeanClass(clazz);
+        beanDefinition.setAutowireMode(ConfigurableListableBeanFactory.AUTOWIRE_NO);
+        beanDefinition.setDependencyCheck(GenericBeanDefinition.DEPENDENCY_CHECK_NONE);
+        if (constructorArgumentValues != null) {
+            beanDefinition.setConstructorArgumentValues(constructorArgumentValues);
+        }
+
+        LOGGER.trace("Registring bean '{}' of type '{}'.", beanName, clazz.getSimpleName());
+
+        registry.registerBeanDefinition(beanName, beanDefinition);
+    }
+
+}

--- a/hawaii-async/src/main/java/org/hawaiiframework/async/config/DelegatingExecutorFactory.java
+++ b/hawaii-async/src/main/java/org/hawaiiframework/async/config/DelegatingExecutorFactory.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawaiiframework.async.config;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hawaiiframework.async.DelegatingExecutor;
+import org.hawaiiframework.async.model.ExecutorConfigurationProperties;
+import org.hawaiiframework.async.model.SystemProperties;
+import org.hawaiiframework.async.model.TaskProperties;
+import org.hawaiiframework.exception.HawaiiException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.core.task.TaskExecutor;
+
+import java.util.Set;
+
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+
+
+/**
+ * Utility to initialize executors for the asynchronous execution of methods using
+ * the @{@link org.springframework.scheduling.annotation.Async}annotation.
+ * <p>
+ * From the configuration, method per system an executor is registered to be used in the {@code @Async("system.method")} annotation.
+ *
+ * @author Rutger Lubbers
+ * @author Paul Klos
+ * @since 3.0.0
+ */
+public class DelegatingExecutorFactory {
+
+    /**
+     * The logger to use.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(DelegatingExecutorFactory.class);
+
+    /**
+     * Spring's bean factory.
+     */
+    private final ConfigurableListableBeanFactory beanFactory;
+
+    /**
+     * Utility to register beans in Spring.
+     */
+    private final BeanRegistrar registrar;
+
+    /**
+     * The executor configuration.
+     */
+    private final ExecutorConfigurationProperties configuration;
+
+    /**
+     * The set of executor names.
+     */
+    private final Set<String> executorNames;
+
+    /**
+     * The constructor.
+     *
+     * @param beanFactory   Spring's bean factory.
+     * @param registrar     Utility to register beans in Spring.
+     * @param configuration The executor configuration.
+     * @param executorNames The set of executor names.
+     */
+    public DelegatingExecutorFactory(final ConfigurableListableBeanFactory beanFactory,
+        final BeanRegistrar registrar, final ExecutorConfigurationProperties configuration,
+        final Set<String> executorNames) {
+        this.beanFactory = beanFactory;
+        this.registrar = registrar;
+        this.configuration = configuration;
+        this.executorNames = executorNames;
+    }
+
+    /**
+     * Create bean aliases for the configured systems.
+     * <p>
+     * For each task in the system an {@link DelegatingExecutor} is created with the relevant executor as its delegate. This is either the
+     * configured executor for the task, or the task's system default executor.
+     * <p>
+     * If neither have a configured executor, no alias is created and the call will default to the default executor.
+     */
+    public void createDelegatingExecutors() {
+        for (final SystemProperties systemProperties : configuration.getSystems()) {
+            final String systemName = systemProperties.getName();
+
+            // This is the fallback if no executor is defined for a task
+            final String systemExecutor = systemProperties.getDefaultExecutor();
+            if (StringUtils.isNotBlank(systemExecutor) && !executorNames.contains(systemExecutor)) {
+                throw new HawaiiException(
+                    String.format("Executor '%s' of system '%s' is not defined.", systemExecutor, systemName));
+            }
+
+            for (final TaskProperties taskProperties : systemProperties.getTasks()) {
+                final String executorName = taskProperties.getExecutor();
+
+                final String taskName = String.format("%s.%s", systemName, taskProperties.getMethod());
+                if (StringUtils.isNotBlank(executorName)) {
+                    if (!executorNames.contains(executorName)) {
+                        throw new HawaiiException(
+                            String.format("Executor '%s' of task '%s' is not defined.", executorName, taskName));
+                    }
+                    LOGGER.debug("Configuring task '{}' to use executor '{}'.", taskName, executorName);
+                } else {
+                    LOGGER.info("No executor defined for task '{}'. Falling back to system executor '{}'.", taskName, systemExecutor);
+                }
+
+                final String executor = defaultIfBlank(executorName, defaultIfBlank(systemExecutor, configuration.getDefaultExecutor()));
+                createTaskExecutorDelegate(taskName, executor);
+            }
+        }
+    }
+
+    /**
+     * Creates a delegating executor for the given task name.
+     */
+    private void createTaskExecutorDelegate(
+        final String taskName,
+        final String executor) {
+        final TaskExecutor delegate = (TaskExecutor) beanFactory.getBean(executor);
+        final ConstructorArgumentValues constructorArgumentValues = new ConstructorArgumentValues();
+        constructorArgumentValues.addIndexedArgumentValue(0, delegate);
+        constructorArgumentValues.addIndexedArgumentValue(1, configuration);
+        constructorArgumentValues.addIndexedArgumentValue(2, taskName);
+        LOGGER.debug("Registering delegate '{}' to for executor '{}'.", taskName, executor);
+        registrar.registerBean(taskName, DelegatingExecutor.class, constructorArgumentValues);
+    }
+
+}

--- a/hawaii-async/src/test/java/org/hawaiiframework/async/AsyncExecutorConfigurationTest.java
+++ b/hawaii-async/src/test/java/org/hawaiiframework/async/AsyncExecutorConfigurationTest.java
@@ -76,18 +76,14 @@ public class AsyncExecutorConfigurationTest {
     @Test
     public void thatDefaultExecutorIsCreated() throws Exception {
         doIt();
-        ThreadPoolTaskExecutor executor = (ThreadPoolTaskExecutor) configuration.getAsyncExecutor();
+        DelegatingExecutor executor = (DelegatingExecutor) configuration.getAsyncExecutor();
         ThreadPoolTaskExecutor defaultExecutor = (ThreadPoolTaskExecutor) beanFactory.getBean(defaultExecutorProperties.getName());
-        assertTrue(executor == defaultExecutor);
+
         final ScheduledThreadPoolExecutor asyncTimeoutExecutor = (ScheduledThreadPoolExecutor) beanFactory.getBean("asyncTimeoutExecutor");
         assertNotNull(asyncTimeoutExecutor);
         assertEquals(properties.getAsyncTimeoutExecutorPoolSize(), (Integer) asyncTimeoutExecutor.getCorePoolSize());
-        assertEquals(defaultExecutorProperties.getCorePoolSize(), (Integer) executor.getCorePoolSize());
-        assertEquals(defaultExecutorProperties.getMaxPoolSize(), (Integer) executor.getMaxPoolSize());
-        assertEquals(defaultExecutorProperties.getKeepAliveTime(), (Integer) executor.getKeepAliveSeconds());
-        assertEquals(defaultExecutorProperties.getMaxPendingRequests(),
-                (Integer) executor.getThreadPoolExecutor().getQueue().remainingCapacity());
-        assertEquals(defaultExecutorProperties.getName() + "-", executor.getThreadNamePrefix());
+
+        assertTrue(executor.hasDelegate(defaultExecutor));
     }
 
     private void doIt() {
@@ -115,7 +111,7 @@ public class AsyncExecutorConfigurationTest {
                 (DelegatingExecutor) beanFactory.getBean(systemProperties.getName() + "." + taskProperties.getMethod());
         assertNotNull(taskExecutor);
 
-        ThreadPoolTaskExecutor defaultExecutor = (ThreadPoolTaskExecutor) configuration.getAsyncExecutor();
+        DelegatingExecutor defaultExecutor = (DelegatingExecutor) configuration.getAsyncExecutor();
         assertEquals(0, defaultExecutor.getActiveCount());
 
         final CountDownLatch taskLatch = new CountDownLatch(1);
@@ -153,7 +149,7 @@ public class AsyncExecutorConfigurationTest {
         assertNotNull(executor);
 
 
-        ThreadPoolTaskExecutor defaultExecutor = (ThreadPoolTaskExecutor) configuration.getAsyncExecutor();
+        DelegatingExecutor defaultExecutor = (DelegatingExecutor) configuration.getAsyncExecutor();
         ThreadPoolTaskExecutor systemExecutor = (ThreadPoolTaskExecutor) beanFactory.getBean(systemExecutorName);
         assertEquals(0, defaultExecutor.getActiveCount());
         assertEquals(0, systemExecutor.getActiveCount());
@@ -199,7 +195,7 @@ public class AsyncExecutorConfigurationTest {
         assertNotNull(executor);
 
 
-        ThreadPoolTaskExecutor defaultExecutor = (ThreadPoolTaskExecutor) configuration.getAsyncExecutor();
+        DelegatingExecutor defaultExecutor = (DelegatingExecutor) configuration.getAsyncExecutor();
         ThreadPoolTaskExecutor systemExecutor = (ThreadPoolTaskExecutor) beanFactory.getBean(systemExecutorName);
         ThreadPoolTaskExecutor taskExecutor = (ThreadPoolTaskExecutor) beanFactory.getBean(taskExecutorName);
         assertEquals(0, defaultExecutor.getActiveCount());
@@ -258,7 +254,7 @@ public class AsyncExecutorConfigurationTest {
         DelegatingExecutor taskExecutor =
                 (DelegatingExecutor) beanFactory.getBean(systemProperties.getName() + "." + taskProperties.getMethod());
 
-        ThreadPoolTaskExecutor defaultExecutor = (ThreadPoolTaskExecutor) configuration.getAsyncExecutor();
+        DelegatingExecutor defaultExecutor = (DelegatingExecutor) configuration.getAsyncExecutor();
         assertEquals(0, defaultExecutor.getActiveCount());
 
         ScheduledThreadPoolExecutor asyncTimeoutExecutor = (ScheduledThreadPoolExecutor) beanFactory.getBean("asyncTimeoutExecutor");
@@ -309,7 +305,7 @@ public class AsyncExecutorConfigurationTest {
         DelegatingExecutor taskExecutor =
                 (DelegatingExecutor) beanFactory.getBean(systemProperties.getName() + "." + taskProperties.getMethod());
 
-        ThreadPoolTaskExecutor defaultExecutor = (ThreadPoolTaskExecutor) configuration.getAsyncExecutor();
+        DelegatingExecutor defaultExecutor = (DelegatingExecutor) configuration.getAsyncExecutor();
         assertEquals(0, defaultExecutor.getActiveCount());
 
         ScheduledThreadPoolExecutor asyncTimeoutExecutor = (ScheduledThreadPoolExecutor) beanFactory.getBean("asyncTimeoutExecutor");


### PR DESCRIPTION
  @Async() without executor name threw and exception.
  The default executor now creates a shared task
  context, which can be used with the task decorator
  to guard the tasks execution.