### PR TITLE
Allow Async annotation without an executor name.

### DIFF
--- a/hawaii-async/src/main/java/org/hawaiiframework/async/DelegatingExecutor.java
+++ b/hawaii-async/src/main/java/org/hawaiiframework/async/DelegatingExecutor.java
@@ -24,8 +24,14 @@ import org.hawaiiframework.async.timeout.SharedTaskContextHolder;
 import org.hawaiiframework.logging.model.KibanaLogFields;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.AsyncListenableTaskExecutor;
+import org.springframework.lang.NonNull;
+import org.springframework.scheduling.SchedulingTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.util.concurrent.ListenableFuture;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
 
 /**
  * Task executor that delegates to the task executor configured for a task.
@@ -37,7 +43,12 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  * @author Paul Klos
  * @since 2.0.0
  */
-public class DelegatingExecutor implements TaskExecutor {
+public class DelegatingExecutor implements AsyncListenableTaskExecutor, SchedulingTaskExecutor {
+
+    /**
+     * The serial version UID.
+     */
+    private static final long serialVersionUID = -8533500008410021569L;
 
     /**
      * Logger for this class.
@@ -87,7 +98,64 @@ public class DelegatingExecutor implements TaskExecutor {
      * Configures a {@link SharedTaskContextHolder} before delegating execution.
      */
     @Override
-    public void execute(final Runnable task) {
+    public void execute(@NonNull final Runnable task) {
+        initializeTask();
+        delegate.execute(task);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Configures a {@link SharedTaskContextHolder} before delegating execution.
+     */
+    @Override
+    public void execute(@NonNull final Runnable task, final long startTimeout) {
+        initializeTask();
+        delegate.execute(task, startTimeout);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Configures a {@link SharedTaskContextHolder} before delegating execution.
+     */
+    @Override
+    public Future<?> submit(@NonNull final Runnable task) {
+        initializeTask();
+        return delegate.submit(task);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Configures a {@link SharedTaskContextHolder} before delegating execution.
+     */
+    @Override public <T> Future<T> submit(@NonNull final Callable<T> task) {
+        initializeTask();
+        return delegate.submit(task);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Configures a {@link SharedTaskContextHolder} before delegating execution.
+     */
+    @Override public ListenableFuture<?> submitListenable(final Runnable task) {
+        initializeTask();
+        return delegate.submitListenable(task);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Configures a {@link SharedTaskContextHolder} before delegating execution.
+     */
+    @Override public <T> ListenableFuture<T> submitListenable(final Callable<T> task) {
+        initializeTask();
+        return delegate.submitListenable(task);
+    }
+
+    private void initializeTask() {
         final SharedTaskContext sharedTaskContext = new SharedTaskContext(taskName, executorConfigurationProperties,
                 executorStatistics, KibanaLogFields.getContext());
         LOGGER.info("Scheduling task '{}' with id '{}'.", sharedTaskContext.getTaskName(), sharedTaskContext.getTaskId());
@@ -96,7 +164,6 @@ public class DelegatingExecutor implements TaskExecutor {
                 executorStatistics.getCompletedTaskCount(), executorStatistics.getAbortedTaskCount());
 
         SharedTaskContextHolder.register(sharedTaskContext);
-        delegate.execute(task);
     }
 
     /**
@@ -104,5 +171,26 @@ public class DelegatingExecutor implements TaskExecutor {
      */
     public ExecutorStatisticsView getExecutorStatistics() {
         return new ExecutorStatisticsView(executorStatistics);
+    }
+
+    /**
+     * For testing purposes.
+     */
+    public boolean hasDelegate(final ThreadPoolTaskExecutor executor) {
+        return delegate.equals(executor);
+    }
+
+    /**
+     * For testing purposes.
+     */
+    public int getActiveCount() {
+        return delegate.getActiveCount();
+    }
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean prefersShortLivedTasks() {
+        return delegate.prefersShortLivedTasks();
     }
 }

--- a/hawaii-async/src/main/java/org/hawaiiframework/async/config/AsyncExecutorInitializer.java
+++ b/hawaii-async/src/main/java/org/hawaiiframework/async/config/AsyncExecutorInitializer.java
@@ -19,6 +19,7 @@ package org.hawaiiframework.async.config;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.hawaiiframework.async.AbortableTaskDecorator;
+import org.hawaiiframework.async.DelegatingExecutor;
 import org.hawaiiframework.async.model.ExecutorConfigurationProperties;
 import org.hawaiiframework.async.model.ExecutorProperties;
 import org.slf4j.Logger;

--- a/hawaii-async/src/main/java/org/hawaiiframework/async/config/AsyncExecutorInitializer.java
+++ b/hawaii-async/src/main/java/org/hawaiiframework/async/config/AsyncExecutorInitializer.java
@@ -98,7 +98,7 @@ public class AsyncExecutorInitializer {
     }
 
     private void registerDefaultExecutor(final ThreadPoolTaskExecutor executor) {
-        defaultExecutor = executor;
+        defaultExecutor = new DelegatingExecutor(executor, configuration, configuration.getDefaultExecutor());
     }
 
     @SuppressWarnings("PMD.CommentRequired")


### PR DESCRIPTION
Currently, the hawaii async breaks the (allowed) @Async annotation. This annotation is then without an executor name.

This patch fixed this issue. 

The executor used is the default executor. This executor is now wrapped by our Delegating Executor, enabling task abortion and pool resource utilization definition and logging. The default executor is configured in the `async-config.yaml`.