### PR TITLE
Small publishing fixes

### DIFF
--- a/.travis-deploy-artifacts.sh
+++ b/.travis-deploy-artifacts.sh
@@ -2,8 +2,11 @@
 
 echo "Publishing..."
 
+HAWAII_FRAMEWORK_VERSION=`cat gradle.properties | grep "version" | cut -d'=' -f2`
+
 # Do not deploy archives when building pull request
-if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_BRANCH" != "2.x" ] || [ "$TRAVIS_PULL_REQUEST" == "true" ]; then
+if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_BRANCH" != "2.x" ] || [ "$TRAVIS_PULL_REQUEST" == "true" ] || [[ $HAWAII_FRAMEWORK_VERSION == *SNAPSHOT* ]]; then
+  echo "Do not publish to sonatype..."
   exit 0
 fi
 
@@ -21,7 +24,6 @@ echo "Publishing archives..."
 
 echo "Publishing Documentation..."
 
-HAWAII_FRAMEWORK_VERSION=`cat gradle.properties | grep "version" | cut -d'=' -f2`
 GH_PAGES_DIR=.gh-pages
 GH_REF=github.com/hawaiifw/hawaii-framework
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ notifications:
     on_success: change
     on_failure: always
     on_start: never
+branches:
+  only:
+    - master
+    - 2.x
 env:
   global:
   # SIGNING_KEY

--- a/build.gradle
+++ b/build.gradle
@@ -224,8 +224,10 @@ configure(subprojects - sampleprojects) { subproject ->
         toolVersion = spotbugsToolVersion
     }
 
-    signing {
-        sign publishing.publications
+    if (project.hasProperty("signing.keyId")) {
+        signing {
+            sign publishing.publications
+        }
     }
 
     publishing.publications {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.0.0.M10
+version=3.0.0.M11-SNAPSHOT


### PR DESCRIPTION
- Added a check to only publish non snapshot versions.
- Only build on the master branch or 2.x branch
- Only sign pom when building with a signing key as parameter
- Updated version to M11-SNAPSHOT