### PR TITLE
Http request and response logging changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -393,7 +393,7 @@ project("hawaii-logging") {
         implementation "org.springframework:spring-web"
         implementation "org.springframework.boot:spring-boot"
         implementation "org.springframework.boot:spring-boot-autoconfigure"
-        compileOnly "org.apache.cxf:cxf-rt-features-logging:${apacheCxfVersion}"
+        implementation "org.apache.cxf:cxf-rt-features-logging:${apacheCxfVersion}"
         compileOnly "ch.qos.logback:logback-core:${logbackVersion}"
         compileOnly "ch.qos.logback:logback-classic:${logbackVersion}"
         compileOnly "org.springframework.security:spring-security-core"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.0.0.M14
+version=3.0.0.M15

--- a/hawaii-autoconfigure/src/main/resources/config/application.yml
+++ b/hawaii-autoconfigure/src/main/resources/config/application.yml
@@ -23,6 +23,13 @@ hawaii:
     opentracing:
       # Must set explicitly to false if opentracing is not required. If the property is not present, the default is "enabled = true".
       enabled: true
+    # For console logging, the allowed content types, empty means allow all,
+    # including binary files, so not a good idea.
+    allowed-content-types:
+    - application/json
+    - text/plain
+    - text/xml
+    - application/vnd.spring-boot.actuator.v1+json
     filters:
       kibana-log-cleanup:
         enabled: true
@@ -52,15 +59,6 @@ hawaii:
       request-response:
         enabled: true
         order: -300
-        fallback-to-file: true
-        directory: /tmp
-        max-log-size: 50k
-        # For console logging, the allowed content types, empty means allow all.
-        allowed-content-types:
-        - application/json
-        - text/plain
-        - text/xml
-        - application/vnd.spring-boot.actuator.v1+json
       container-name:
         enabled: true
         http-header: X-Hawaii-Hostname

--- a/hawaii-cache/src/test/java/org/hawaiiframework/cache/redis/RedisCacheTest.java
+++ b/hawaii-cache/src/test/java/org/hawaiiframework/cache/redis/RedisCacheTest.java
@@ -37,7 +37,11 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RedisCacheTest {

--- a/hawaii-core/src/main/java/org/hawaiiframework/crypto/HawaiiStringEncryptor.java
+++ b/hawaii-core/src/main/java/org/hawaiiframework/crypto/HawaiiStringEncryptor.java
@@ -93,7 +93,7 @@ public class HawaiiStringEncryptor implements StringEncryptor {
         }
     }
 
-    private Cipher initCipher(final int mode, final String key, final String initVector)
+    protected Cipher initCipher(final int mode, final String key, final String initVector)
             throws GeneralSecurityException {
         final Cipher cipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
 

--- a/hawaii-core/src/main/java/org/hawaiiframework/crypto/HawaiiUrlSafeStringEncryptor.java
+++ b/hawaii-core/src/main/java/org/hawaiiframework/crypto/HawaiiUrlSafeStringEncryptor.java
@@ -1,0 +1,74 @@
+package org.hawaiiframework.crypto;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.Strings;
+import org.bouncycastle.util.encoders.UrlBase64;
+import org.hawaiiframework.exception.HawaiiException;
+
+import javax.crypto.Cipher;
+import java.nio.charset.Charset;
+import java.security.GeneralSecurityException;
+import java.security.Security;
+
+
+/**
+ * Hawaii String Encryptor with Url safe base64 encoding.
+ */
+public class HawaiiUrlSafeStringEncryptor extends HawaiiStringEncryptor {
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    private final String key;
+    private final String initVector;
+
+    /**
+     * Creates a new {@code HawaiiUrlSafeStringEncryptor} with the given key and init vector.
+     *
+     * @param key        the key used for encryption/decryption
+     * @param initVector the init vector used for encryption/decryption
+     */
+    public HawaiiUrlSafeStringEncryptor(final String key, final String initVector) {
+        super(key, initVector);
+        this.key = key;
+        this.initVector = initVector;
+    }
+
+    /**
+     * Encrypt the input message.
+     *
+     * @param message the message to be encrypted
+     * @return the result of encryption
+     */
+    @Override
+    public String encrypt(final String message) {
+        try {
+            final Cipher cipher = initCipher(Cipher.ENCRYPT_MODE, key, initVector);
+            final byte[] encrypted = cipher.doFinal(message.getBytes(Charset.defaultCharset()));
+
+            final byte[] encoded = UrlBase64.encode(encrypted);
+            return Strings.fromByteArray(encoded);
+        } catch (GeneralSecurityException e) {
+            throw new HawaiiException("Error encrypting message", e);
+        }
+    }
+
+    /**
+     * Decrypt the encrypted input message.
+     *
+     * @param encryptedMessage the message to be decrypted
+     * @return the result of decryption
+     */
+    @Override
+    public String decrypt(final String encryptedMessage) {
+        try {
+            final Cipher cipher = initCipher(Cipher.DECRYPT_MODE, key, initVector);
+            final byte[] decrypted = cipher.doFinal(UrlBase64.decode(encryptedMessage));
+            return new String(decrypted, Charset.defaultCharset());
+        } catch (GeneralSecurityException e) {
+            throw new HawaiiException("Error decrypting message", e);
+        }
+    }
+
+}

--- a/hawaii-core/src/main/java/org/hawaiiframework/time/HawaiiTime.java
+++ b/hawaii-core/src/main/java/org/hawaiiframework/time/HawaiiTime.java
@@ -16,7 +16,20 @@
 
 package org.hawaiiframework.time;
 
-import java.time.*;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import static java.util.Objects.requireNonNull;
 

--- a/hawaii-core/src/test/java/org/hawaiiframework/converter/PersonInput.java
+++ b/hawaii-core/src/test/java/org/hawaiiframework/converter/PersonInput.java
@@ -1,7 +1,5 @@
 package org.hawaiiframework.converter;
 
-import java.util.List;
-
 /**
  * Sample bean to convert.
  */

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfiguration.java
@@ -19,8 +19,9 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
 import org.apache.cxf.ext.logging.LoggingInInterceptor;
 import org.apache.cxf.ext.logging.LoggingOutInterceptor;
-import org.hawaiiframework.logging.config.filter.HawaiiLoggingConfigurationProperties;
 import org.hawaiiframework.logging.http.client.LoggingClientHttpRequestInterceptor;
+import org.hawaiiframework.logging.http.DefaultHawaiiRequestResponseLogger;
+import org.hawaiiframework.logging.http.HawaiiRequestResponseLogger;
 import org.hawaiiframework.logging.util.HttpRequestResponseLogUtil;
 import org.hawaiiframework.sql.DataSourceProxyConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -55,21 +56,28 @@ public class HawaiiLoggingConfiguration {
      * @return the bean.
      */
     @Bean
-    @ConditionalOnProperty(prefix = "hawaii.logging.filters.request-response", name = "enabled")
     public HttpRequestResponseLogUtil httpRequestResponseLogUtil() {
         return new HttpRequestResponseLogUtil();
     }
 
+    @Bean
+    public HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties() {
+        return new HawaiiLoggingConfigurationProperties();
+    }
+
+    @Bean
+    public HawaiiRequestResponseLogger hawaiiLogger(final HttpRequestResponseLogUtil requestResponseLogUtil,
+            final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
+        return new DefaultHawaiiRequestResponseLogger(requestResponseLogUtil, hawaiiLoggingConfigurationProperties);
+    }
+
     /**
      * Create a {@link LoggingClientHttpRequestInterceptor} bean.
-     *
-     * @param requestResponseLogUtil The HTTP request response log utility.
      * @return the bean.
      */
     @Bean
-    public LoggingClientHttpRequestInterceptor loggingClientHttpRequestInterceptor(
-            final HttpRequestResponseLogUtil requestResponseLogUtil) {
-        return new LoggingClientHttpRequestInterceptor(requestResponseLogUtil);
+    public LoggingClientHttpRequestInterceptor loggingClientHttpRequestInterceptor() {
+        return new LoggingClientHttpRequestInterceptor(hawaiiLogger(httpRequestResponseLogUtil(), hawaiiLoggingConfigurationProperties()));
     }
 
     /**

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfiguration.java
@@ -24,6 +24,7 @@ import org.hawaiiframework.logging.http.DefaultHawaiiRequestResponseLogger;
 import org.hawaiiframework.logging.http.HawaiiRequestResponseLogger;
 import org.hawaiiframework.logging.util.HttpRequestResponseLogUtil;
 import org.hawaiiframework.sql.DataSourceProxyConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -65,19 +66,21 @@ public class HawaiiLoggingConfiguration {
         return new HawaiiLoggingConfigurationProperties();
     }
 
-    @Bean
-    public HawaiiRequestResponseLogger hawaiiLogger(final HttpRequestResponseLogUtil requestResponseLogUtil,
-            final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
-        return new DefaultHawaiiRequestResponseLogger(requestResponseLogUtil, hawaiiLoggingConfigurationProperties);
-    }
-
     /**
      * Create a {@link LoggingClientHttpRequestInterceptor} bean.
      * @return the bean.
      */
     @Bean
-    public LoggingClientHttpRequestInterceptor loggingClientHttpRequestInterceptor() {
-        return new LoggingClientHttpRequestInterceptor(hawaiiLogger(httpRequestResponseLogUtil(), hawaiiLoggingConfigurationProperties()));
+    public LoggingClientHttpRequestInterceptor loggingClientHttpRequestInterceptor(
+            final HawaiiRequestResponseLogger hawaiiRequestResponseLogger) {
+        return new LoggingClientHttpRequestInterceptor(hawaiiRequestResponseLogger);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(HawaiiRequestResponseLogger.class)
+    public HawaiiRequestResponseLogger hawaiiLogger(final HttpRequestResponseLogUtil requestResponseLogUtil,
+            final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
+        return new DefaultHawaiiRequestResponseLogger(requestResponseLogUtil, hawaiiLoggingConfigurationProperties);
     }
 
     /**

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfigurationProperties.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfigurationProperties.java
@@ -1,0 +1,25 @@
+package org.hawaiiframework.logging.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Properties used by {@HawaiiLoggingConfiguration}.
+ */
+@Component
+@ConfigurationProperties(prefix = "hawaii.logging")
+public class HawaiiLoggingConfigurationProperties {
+
+    private List<String> allowedContentTypes;
+
+    public List<String> getAllowedContentTypes() {
+        return allowedContentTypes;
+    }
+
+    public void setAllowedContentTypes(final List<String> allowedContentTypes) {
+        this.allowedContentTypes = allowedContentTypes;
+    }
+
+}

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingFilterConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingFilterConfiguration.java
@@ -16,6 +16,7 @@
 package org.hawaiiframework.logging.config;
 
 import org.hawaiiframework.logging.config.filter.ContainerNameHttpHeaderFilterConfiguration;
+import org.hawaiiframework.logging.config.filter.HawaiiLoggingFilterConfigurationProperties;
 import org.hawaiiframework.logging.config.filter.KibanaLogCleanupFilterConfiguration;
 import org.hawaiiframework.logging.config.filter.OpentracingResponseFilterConfiguration;
 import org.hawaiiframework.logging.config.filter.RequestDurationFilterConfiguration;
@@ -24,6 +25,7 @@ import org.hawaiiframework.logging.config.filter.RequestResponseLogFilterConfigu
 import org.hawaiiframework.logging.config.filter.TransactionIdFilterConfiguration;
 import org.hawaiiframework.logging.config.filter.TransactionTypeFilterConfiguration;
 import org.hawaiiframework.logging.config.filter.UserDetailsFilterConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -31,6 +33,7 @@ import org.springframework.context.annotation.Import;
  * Configuration that includes all filter configurations.
  */
 @Configuration
+@EnableConfigurationProperties(HawaiiLoggingFilterConfigurationProperties.class)
 @Import({
         ContainerNameHttpHeaderFilterConfiguration.class,
         KibanaLogCleanupFilterConfiguration.class,

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/ContainerNameHttpHeaderFilterConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/ContainerNameHttpHeaderFilterConfiguration.java
@@ -32,15 +32,16 @@ public class ContainerNameHttpHeaderFilterConfiguration {
     /**
      * The logging configuration properties.
      */
-    private final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties;
+    private final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties;
 
     /**
      * The constructor.
      *
-     * @param hawaiiLoggingConfigurationProperties The logging configuration properties.
+     * @param hawaiiLoggingFilterConfigurationProperties The logging configuration properties.
      */
-    public ContainerNameHttpHeaderFilterConfiguration(final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
-        this.hawaiiLoggingConfigurationProperties = hawaiiLoggingConfigurationProperties;
+    public ContainerNameHttpHeaderFilterConfiguration(
+            final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties) {
+        this.hawaiiLoggingFilterConfigurationProperties = hawaiiLoggingFilterConfigurationProperties;
     }
 
     /**
@@ -51,7 +52,7 @@ public class ContainerNameHttpHeaderFilterConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.container-name", name = "enabled")
     public ContainerNameHttpHeaderFilter containerNameHttpHeaderFilter() {
-        final ContainerNameHttpHeaderFilterProperties filterProperties = hawaiiLoggingConfigurationProperties.getContainerName();
+        final ContainerNameHttpHeaderFilterProperties filterProperties = hawaiiLoggingFilterConfigurationProperties.getContainerName();
         return new ContainerNameHttpHeaderFilter(filterProperties);
     }
 
@@ -66,7 +67,7 @@ public class ContainerNameHttpHeaderFilterConfiguration {
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.container-name", name = "enabled")
     public FilterRegistrationBean<ContainerNameHttpHeaderFilter> containerNameHttpHeaderFilterRegistration(
             final ContainerNameHttpHeaderFilter filter) {
-        final HttpHeaderLoggingFilterProperties filterProperties = hawaiiLoggingConfigurationProperties.getContainerName();
+        final HttpHeaderLoggingFilterProperties filterProperties = hawaiiLoggingFilterConfigurationProperties.getContainerName();
         return createFilterRegistrationBean(filter, filterProperties);
     }
 

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/HawaiiLoggingFilterConfigurationProperties.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/HawaiiLoggingFilterConfigurationProperties.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "hawaii.logging.filters")
 @SuppressWarnings("PMD.DataClass")
-public class HawaiiLoggingConfigurationProperties {
+public class HawaiiLoggingFilterConfigurationProperties {
 
     /**
      * Configuration properties for the Kibana log filter.

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/KibanaLogCleanupFilterConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/KibanaLogCleanupFilterConfiguration.java
@@ -33,15 +33,16 @@ public class KibanaLogCleanupFilterConfiguration {
     /**
      * The logging configuration properties.
      */
-    private final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties;
+    private final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties;
 
     /**
      * The constructor.
      *
-     * @param hawaiiLoggingConfigurationProperties The logging configuration properties.
+     * @param hawaiiLoggingFilterConfigurationProperties The logging configuration properties.
      */
-    public KibanaLogCleanupFilterConfiguration(final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
-        this.hawaiiLoggingConfigurationProperties = hawaiiLoggingConfigurationProperties;
+    public KibanaLogCleanupFilterConfiguration(
+            final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties) {
+        this.hawaiiLoggingFilterConfigurationProperties = hawaiiLoggingFilterConfigurationProperties;
     }
 
     /**
@@ -65,7 +66,7 @@ public class KibanaLogCleanupFilterConfiguration {
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.kibana-log-cleanup", name = "enabled")
     public FilterRegistrationBean<KibanaLogCleanupFilter> kibanaLogCleanupFilterRegistration(
             final KibanaLogCleanupFilter kibanaLogCleanupFilter) {
-        final LoggingFilterProperties filterProperties = hawaiiLoggingConfigurationProperties.getKibanaLogCleanup();
+        final LoggingFilterProperties filterProperties = hawaiiLoggingFilterConfigurationProperties.getKibanaLogCleanup();
         return createFilterRegistrationBean(kibanaLogCleanupFilter, filterProperties);
     }
 

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/KibanaLogFilterConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/KibanaLogFilterConfiguration.java
@@ -34,15 +34,15 @@ public class KibanaLogFilterConfiguration {
     /**
      * The logging configuration properties.
      */
-    private final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties;
+    private final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties;
 
     /**
      * The constructor.
      *
-     * @param hawaiiLoggingConfigurationProperties The logging configuration properties.
+     * @param hawaiiLoggingFilterConfigurationProperties The logging configuration properties.
      */
-    public KibanaLogFilterConfiguration(final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
-        this.hawaiiLoggingConfigurationProperties = hawaiiLoggingConfigurationProperties;
+    public KibanaLogFilterConfiguration(final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties) {
+        this.hawaiiLoggingFilterConfigurationProperties = hawaiiLoggingFilterConfigurationProperties;
     }
 
     /**
@@ -53,7 +53,7 @@ public class KibanaLogFilterConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.kibana-log", name = "enabled")
     public KibanaLogFilter kibanaLogFilter() {
-        return new KibanaLogFilter(createClientIpResolver(hawaiiLoggingConfigurationProperties.getKibanaLog()));
+        return new KibanaLogFilter(createClientIpResolver(hawaiiLoggingFilterConfigurationProperties.getKibanaLog()));
     }
 
     /**
@@ -65,7 +65,7 @@ public class KibanaLogFilterConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.kibana-log", name = "enabled")
     public FilterRegistrationBean<KibanaLogFilter> kibanaLogFilterRegistration(final KibanaLogFilter kibanaLogFilter) {
-        final HttpHeaderLoggingFilterProperties filterProperties = hawaiiLoggingConfigurationProperties.getKibanaLog();
+        final HttpHeaderLoggingFilterProperties filterProperties = hawaiiLoggingFilterConfigurationProperties.getKibanaLog();
         return createFilterRegistrationBean(kibanaLogFilter, filterProperties);
     }
 

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/OpentracingResponseFilterConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/OpentracingResponseFilterConfiguration.java
@@ -39,15 +39,16 @@ public class OpentracingResponseFilterConfiguration {
     /**
      * The the logging configuration properties.
      */
-    private final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties;
+    private final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties;
 
     /**
      * Autowired constructor.
      *
-     * @param hawaiiLoggingConfigurationProperties the logging configuration properties
+     * @param hawaiiLoggingFilterConfigurationProperties the logging configuration properties
      */
-    public OpentracingResponseFilterConfiguration(final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
-        this.hawaiiLoggingConfigurationProperties = hawaiiLoggingConfigurationProperties;
+    public OpentracingResponseFilterConfiguration(
+            final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties) {
+        this.hawaiiLoggingFilterConfigurationProperties = hawaiiLoggingFilterConfigurationProperties;
     }
 
     /**
@@ -81,7 +82,7 @@ public class OpentracingResponseFilterConfiguration {
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.opentracing-response", name = "enabled", matchIfMissing = true)
     public FilterRegistrationBean<OpentracingResponseFilter> opentracingResponseFilterRegistration(
             final OpentracingResponseFilter opentracingResponseFilter) {
-        final LoggingFilterProperties filterProperties = hawaiiLoggingConfigurationProperties.getOpentracingResponse();
+        final LoggingFilterProperties filterProperties = hawaiiLoggingFilterConfigurationProperties.getOpentracingResponse();
         return createFilterRegistrationBean(opentracingResponseFilter, filterProperties);
     }
 }

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/RequestDurationFilterConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/RequestDurationFilterConfiguration.java
@@ -33,15 +33,15 @@ public class RequestDurationFilterConfiguration {
     /**
      * The logging configuration properties.
      */
-    private final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties;
+    private final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties;
 
     /**
      * The constructor.
      *
-     * @param hawaiiLoggingConfigurationProperties The logging configuration properties.
+     * @param hawaiiLoggingFilterConfigurationProperties The logging configuration properties.
      */
-    public RequestDurationFilterConfiguration(final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
-        this.hawaiiLoggingConfigurationProperties = hawaiiLoggingConfigurationProperties;
+    public RequestDurationFilterConfiguration(final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties) {
+        this.hawaiiLoggingFilterConfigurationProperties = hawaiiLoggingFilterConfigurationProperties;
     }
 
     /**
@@ -65,7 +65,7 @@ public class RequestDurationFilterConfiguration {
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.request-duration", name = "enabled")
     public FilterRegistrationBean<RequestDurationFilter> requestDurationFilterRegistration(
             final RequestDurationFilter requestDurationFilter) {
-        final LoggingFilterProperties filterProperties = hawaiiLoggingConfigurationProperties.getRequestDuration();
+        final LoggingFilterProperties filterProperties = hawaiiLoggingFilterConfigurationProperties.getRequestDuration();
         return createFilterRegistrationBean(requestDurationFilter, filterProperties);
     }
 }

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/RequestIdFilterConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/RequestIdFilterConfiguration.java
@@ -33,15 +33,15 @@ public class RequestIdFilterConfiguration {
     /**
      * The logging configuration properties.
      */
-    private final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties;
+    private final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties;
 
     /**
      * The constructor.
      *
-     * @param hawaiiLoggingConfigurationProperties The logging configuration properties.
+     * @param hawaiiLoggingFilterConfigurationProperties The logging configuration properties.
      */
-    public RequestIdFilterConfiguration(final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
-        this.hawaiiLoggingConfigurationProperties = hawaiiLoggingConfigurationProperties;
+    public RequestIdFilterConfiguration(final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties) {
+        this.hawaiiLoggingFilterConfigurationProperties = hawaiiLoggingFilterConfigurationProperties;
     }
 
     /**
@@ -52,7 +52,7 @@ public class RequestIdFilterConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.request-id", name = "enabled")
     public RequestIdFilter requestIdFilter() {
-        final HttpHeaderLoggingFilterProperties filterProperties = hawaiiLoggingConfigurationProperties.getRequestId();
+        final HttpHeaderLoggingFilterProperties filterProperties = hawaiiLoggingFilterConfigurationProperties.getRequestId();
         return new RequestIdFilter(filterProperties.getHttpHeader());
     }
 
@@ -64,7 +64,7 @@ public class RequestIdFilterConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.request-id", name = "enabled")
     public FilterRegistrationBean<RequestIdFilter> requestIdFilterRegistration(final RequestIdFilter requestIdFilter) {
-        final HttpHeaderLoggingFilterProperties filterProperties = hawaiiLoggingConfigurationProperties.getRequestId();
+        final HttpHeaderLoggingFilterProperties filterProperties = hawaiiLoggingFilterConfigurationProperties.getRequestId();
         return createFilterRegistrationBean(requestIdFilter, filterProperties);
     }
 

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/RequestResponseLogFilterConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/RequestResponseLogFilterConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.hawaiiframework.logging.config.filter;
 
-import org.hawaiiframework.logging.util.HttpRequestResponseLogUtil;
+import org.hawaiiframework.logging.http.HawaiiRequestResponseLogger;
 import org.hawaiiframework.logging.web.filter.RequestResponseLogFilter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -34,15 +34,20 @@ public class RequestResponseLogFilterConfiguration {
     /**
      * The logging configuration properties.
      */
-    private final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties;
+    private final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties;
+
+    private final HawaiiRequestResponseLogger hawaiiLogger;
 
     /**
      * The constructor.
      *
-     * @param hawaiiLoggingConfigurationProperties The logging configuration properties.
+     * @param hawaiiLoggingFilterConfigurationProperties The logging configuration properties.
      */
-    public RequestResponseLogFilterConfiguration(final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
-        this.hawaiiLoggingConfigurationProperties = hawaiiLoggingConfigurationProperties;
+    public RequestResponseLogFilterConfiguration(
+            final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties,
+            final HawaiiRequestResponseLogger hawaiiLogger) {
+        this.hawaiiLoggingFilterConfigurationProperties = hawaiiLoggingFilterConfigurationProperties;
+        this.hawaiiLogger = hawaiiLogger;
     }
 
     /**
@@ -52,20 +57,20 @@ public class RequestResponseLogFilterConfiguration {
      */
     @Bean
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.request-response", name = "enabled")
-    public RequestResponseLogFilter requestResponseLogFilter(final HttpRequestResponseLogUtil httpRequestResponseLogUtil) {
-        return new RequestResponseLogFilter(hawaiiLoggingConfigurationProperties.getRequestResponse(), httpRequestResponseLogUtil);
+    public RequestResponseLogFilter requestResponseLogFilter() {
+        return new RequestResponseLogFilter(hawaiiLogger);
     }
 
     /**
      * Create and register the {@link RequestResponseLogFilter} bean.
      *
-     * @return the {@link #requestResponseLogFilter(HttpRequestResponseLogUtil)} bean, wrapped in a {@link FilterRegistrationBean}
+     * @return the requestResponseLogFilter bean, wrapped in a {@link FilterRegistrationBean}
      */
     @Bean
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.request-response", name = "enabled")
     public FilterRegistrationBean<RequestResponseLogFilter> requestResponseLogFilterRegistration(
             final RequestResponseLogFilter requestResponseLogFilter) {
-        final RequestResponseLogFilterProperties filterProperties = hawaiiLoggingConfigurationProperties.getRequestResponse();
+        final RequestResponseLogFilterProperties filterProperties = hawaiiLoggingFilterConfigurationProperties.getRequestResponse();
         return createFilterRegistrationBean(requestResponseLogFilter, filterProperties);
     }
 

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/TransactionIdFilterConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/TransactionIdFilterConfiguration.java
@@ -33,15 +33,15 @@ public class TransactionIdFilterConfiguration {
     /**
      * The logging configuration properties.
      */
-    private final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties;
+    private final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties;
 
     /**
      * The constructor.
      *
-     * @param hawaiiLoggingConfigurationProperties The logging configuration properties.
+     * @param hawaiiLoggingFilterConfigurationProperties The logging configuration properties.
      */
-    public TransactionIdFilterConfiguration(final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
-        this.hawaiiLoggingConfigurationProperties = hawaiiLoggingConfigurationProperties;
+    public TransactionIdFilterConfiguration(final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties) {
+        this.hawaiiLoggingFilterConfigurationProperties = hawaiiLoggingFilterConfigurationProperties;
     }
 
     /**
@@ -52,7 +52,7 @@ public class TransactionIdFilterConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.transaction-id", name = "enabled")
     public TransactionIdFilter transactionIdFilter() {
-        final HttpHeaderLoggingFilterProperties filterProperties = hawaiiLoggingConfigurationProperties.getTransactionId();
+        final HttpHeaderLoggingFilterProperties filterProperties = hawaiiLoggingFilterConfigurationProperties.getTransactionId();
         return new TransactionIdFilter(filterProperties.getHttpHeader());
     }
 
@@ -65,7 +65,7 @@ public class TransactionIdFilterConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.transaction-id", name = "enabled")
     public FilterRegistrationBean<TransactionIdFilter> transactionIdFilterRegistration(final TransactionIdFilter transactionIdFilter) {
-        final HttpHeaderLoggingFilterProperties filterProperties = hawaiiLoggingConfigurationProperties.getTransactionId();
+        final HttpHeaderLoggingFilterProperties filterProperties = hawaiiLoggingFilterConfigurationProperties.getTransactionId();
         return createFilterRegistrationBean(transactionIdFilter, filterProperties);
     }
 

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/TransactionTypeFilterConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/TransactionTypeFilterConfiguration.java
@@ -34,15 +34,15 @@ public class TransactionTypeFilterConfiguration {
     /**
      * The logging configuration properties.
      */
-    private final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties;
+    private final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties;
 
     /**
      * The constructor.
      *
-     * @param hawaiiLoggingConfigurationProperties The logging configuration properties.
+     * @param hawaiiLoggingFilterConfigurationProperties The logging configuration properties.
      */
-    public TransactionTypeFilterConfiguration(final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
-        this.hawaiiLoggingConfigurationProperties = hawaiiLoggingConfigurationProperties;
+    public TransactionTypeFilterConfiguration(final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties) {
+        this.hawaiiLoggingFilterConfigurationProperties = hawaiiLoggingFilterConfigurationProperties;
     }
 
     /**
@@ -67,7 +67,7 @@ public class TransactionTypeFilterConfiguration {
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.transaction-name", name = "enabled")
     public FilterRegistrationBean<TransactionTypeFilter> transactionTypeFilterRegistration(
             final TransactionTypeFilter transactionNameFilter) {
-        final var filterProperties = hawaiiLoggingConfigurationProperties.getTransactionType();
+        final var filterProperties = hawaiiLoggingFilterConfigurationProperties.getTransactionType();
         return createFilterRegistrationBean(transactionNameFilter, filterProperties);
     }
 }

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/UserDetailsFilterConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/filter/UserDetailsFilterConfiguration.java
@@ -38,16 +38,16 @@ public class UserDetailsFilterConfiguration {
     /**
      * The the logging configuration properties.
      */
-    private final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties;
+    private final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties;
 
     /**
      * Autowired constructor.
      *
-     * @param hawaiiLoggingConfigurationProperties the logging configuration properties
+     * @param hawaiiLoggingFilterConfigurationProperties the logging configuration properties
      */
     UserDetailsFilterConfiguration(
-            final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
-        this.hawaiiLoggingConfigurationProperties = hawaiiLoggingConfigurationProperties;
+            final HawaiiLoggingFilterConfigurationProperties hawaiiLoggingFilterConfigurationProperties) {
+        this.hawaiiLoggingFilterConfigurationProperties = hawaiiLoggingFilterConfigurationProperties;
     }
 
     /**
@@ -70,7 +70,7 @@ public class UserDetailsFilterConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "hawaii.logging.filters.user-details", name = "enabled")
     public FilterRegistrationBean<UserDetailsFilter> userDetailsFilterRegistration(final UserDetailsFilter userDetailsFilter) {
-        final LoggingFilterProperties filterProperties = hawaiiLoggingConfigurationProperties.getUserDetails();
+        final LoggingFilterProperties filterProperties = hawaiiLoggingFilterConfigurationProperties.getUserDetails();
         final FilterRegistrationBean<UserDetailsFilter> result = new FilterRegistrationBean<>(userDetailsFilter);
         result.setOrder(filterProperties.getOrder());
         result.setDispatcherTypes(EnumSet.of(DispatcherType.REQUEST));

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
@@ -1,0 +1,203 @@
+package org.hawaiiframework.logging.http;
+
+import org.hawaiiframework.logging.config.HawaiiLoggingConfigurationProperties;
+import org.hawaiiframework.logging.model.AutoCloseableKibanaLogField;
+import org.hawaiiframework.logging.model.KibanaLogFields;
+import org.hawaiiframework.logging.util.HttpRequestResponseLogUtil;
+import org.hawaiiframework.logging.web.filter.ContentCachingWrappedResponse;
+import org.hawaiiframework.logging.web.filter.ResettableHttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
+
+import static org.hawaiiframework.logging.model.KibanaLogCallResultTypes.BACKEND_FAILURE;
+import static org.hawaiiframework.logging.model.KibanaLogCallResultTypes.SUCCESS;
+import static org.hawaiiframework.logging.model.KibanaLogFieldNames.CALL_METHOD;
+import static org.hawaiiframework.logging.model.KibanaLogFieldNames.HTTP_STATUS;
+import static org.hawaiiframework.logging.model.KibanaLogTypeNames.CALL_REQUEST_BODY;
+import static org.hawaiiframework.logging.model.KibanaLogTypeNames.CALL_RESPONSE_BODY;
+import static org.hawaiiframework.logging.model.KibanaLogTypeNames.REQUEST_BODY;
+import static org.hawaiiframework.logging.model.KibanaLogTypeNames.RESPONSE_BODY;
+
+/**
+ * General logger.
+ */
+@SuppressWarnings("PMD.ExcessiveImports")
+public class DefaultHawaiiRequestResponseLogger implements HawaiiRequestResponseLogger {
+
+    /**
+     * The logger to use.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultHawaiiRequestResponseLogger.class);
+
+
+    /**
+     * The request/response log util to use for generating log statements.
+     */
+    private final HttpRequestResponseLogUtil httpRequestResponseLogUtil;
+
+    /**
+     * The configuration to use.
+     */
+    private final HawaiiLoggingConfigurationProperties configuration;
+
+    public DefaultHawaiiRequestResponseLogger(final HttpRequestResponseLogUtil httpRequestResponseLogUtil,
+            final HawaiiLoggingConfigurationProperties configuration) {
+        this.httpRequestResponseLogUtil = httpRequestResponseLogUtil;
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void logRequest(final HttpRequest request, final byte[] body) {
+        try (AutoCloseableKibanaLogField callMethod = KibanaLogFields.tagCloseable(CALL_METHOD, request.getMethodValue());
+                AutoCloseableKibanaLogField kibanaLogField = KibanaLogFields.logType(CALL_REQUEST_BODY)) {
+
+            final String contentType = getContentType(request);
+            if (contentTypeCanBeLogged(contentType)) {
+                logContent(request, body);
+            }
+        }
+    }
+
+    @Override
+    public void logRequest(final ResettableHttpServletRequest wrappedRequest) throws IOException {
+        final String requestUri = wrappedRequest.getRequestURI();
+        final int contentLength = wrappedRequest.getContentLength();
+        final String contentType = wrappedRequest.getContentType();
+
+        try (AutoCloseableKibanaLogField kibanaLogField = KibanaLogFields.logType(REQUEST_BODY)) {
+            LOGGER.info("Invoked '{}' with content type '{}' and size of '{}' bytes.", requestUri, contentType, contentLength);
+            try {
+                if (contentTypeCanBeLogged(contentType)) {
+                    logContent(wrappedRequest);
+                }
+            } finally {
+                wrappedRequest.reset();
+            }
+        }
+    }
+
+    @Override
+    public void logResponse(final ClientHttpResponse response) throws IOException {
+        if (contentTypeCanBeLogged(getContentType(response))) {
+            logContent(response);
+        }
+    }
+
+    @Override
+    public void logResponse(final HttpServletRequest servletRequest,
+            final ContentCachingWrappedResponse wrappedResponse)
+            throws IOException {
+
+        final String request = httpRequestResponseLogUtil.getRequestUri(servletRequest);
+        final int contentLength = wrappedResponse.getContentSize();
+        final String contentType = wrappedResponse.getContentType();
+        final HttpStatus httpStatus = HttpStatus.valueOf(wrappedResponse.getStatus());
+
+        KibanaLogFields.set(HTTP_STATUS, httpStatus.value());
+        try (AutoCloseableKibanaLogField kibanaLogField = KibanaLogFields.logType(RESPONSE_BODY)) {
+            LOGGER.info("Response '{}' is '{} {}' with content type '{}' and size of '{}' bytes.", request,
+                    httpStatus.value(), httpStatus.getReasonPhrase(), contentType, contentLength);
+            if (contentTypeCanBeLogged(contentType)) {
+                logContent(servletRequest, wrappedResponse);
+            }
+        }
+    }
+
+    private void logResponse(final HttpStatus statusCode, final String statusText, final HttpHeaders headers, final String body) {
+        try (AutoCloseableKibanaLogField kibanaLogField = KibanaLogFields.logType(CALL_RESPONSE_BODY)) {
+            if (statusCode.is2xxSuccessful() || statusCode.is3xxRedirection()) {
+                KibanaLogFields.callResult(SUCCESS);
+            } else {
+                KibanaLogFields.callResult(BACKEND_FAILURE);
+            }
+
+            LOGGER.info("Got response '{} {}':\n{}", statusCode, statusText, httpRequestResponseLogUtil.createLogString(headers, body));
+        }
+    }
+
+    public void logContent(final HttpRequest request, final byte[] body) {
+        LOGGER.info("Called '{} {}':\n{}", request.getMethod(), request.getURI(),
+                httpRequestResponseLogUtil.createLogString(request.getHeaders(), body));
+    }
+
+    public void logContent(final ResettableHttpServletRequest wrappedRequest) throws IOException {
+        final String requestUri = wrappedRequest.getRequestURI();
+        LOGGER.info("Request is:\n{}", httpRequestResponseLogUtil.formatRequest(requestUri, wrappedRequest));
+    }
+
+    public void logContent(final HttpServletRequest servletRequest,
+            final ContentCachingWrappedResponse wrappedResponse) throws IOException {
+        final int contentLength = wrappedResponse.getContentSize();
+        final HttpStatus httpStatus = HttpStatus.valueOf(wrappedResponse.getStatus());
+
+        LOGGER.info("Response is:\n{}",
+                httpRequestResponseLogUtil.createLogString(servletRequest, wrappedResponse, httpStatus, contentLength));
+    }
+
+    public void logContent(final ClientHttpResponse response) throws IOException {
+        final HttpStatus statusCode = response.getStatusCode();
+        final String statusText = response.getStatusText();
+
+        final String body = httpRequestResponseLogUtil.getResponseBody(response);
+        logResponse(statusCode, statusText, response.getHeaders(), body);
+    }
+
+
+
+    private String getContentType(final ClientHttpResponse response) throws IOException {
+
+        if (response.getStatusCode().equals(HttpStatus.NO_CONTENT)) {
+            return null;
+        }
+
+        final HttpHeaders httpHeaders = getHttpHeaders(response);
+        final MediaType contentType = getMediaType(httpHeaders);
+        return getContentTypeAsString(contentType);
+    }
+
+    private String getContentType(final HttpRequest request) {
+        final HttpHeaders httpHeaders = getHttpHeaders(request);
+        final MediaType contentType = getMediaType(httpHeaders);
+        return getContentTypeAsString(contentType);
+    }
+
+    private HttpHeaders getHttpHeaders(final ClientHttpResponse response) {
+        return response.getHeaders();
+    }
+
+    private HttpHeaders getHttpHeaders(final HttpRequest request) {
+        return request.getHeaders();
+    }
+
+
+    private MediaType getMediaType(final HttpHeaders httpHeaders) {
+        return httpHeaders.getContentType();
+    }
+
+    private String getContentTypeAsString(final MediaType mediaType) {
+        return mediaType.getType() + '/' + mediaType.getSubtype();
+    }
+
+    public boolean contentTypeCanBeLogged(final String contentType) {
+        //Assume nothing has ben configured so we allow everything
+        if (getAllowedContentTypes() == null || getAllowedContentTypes().isEmpty()) {
+            return true;
+        } else {
+            return getAllowedContentTypes().contains(contentType);
+        }
+    }
+
+    private List<String> getAllowedContentTypes() {
+        return configuration.getAllowedContentTypes();
+    }
+
+}

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
@@ -153,19 +153,17 @@ public class DefaultHawaiiRequestResponseLogger implements HawaiiRequestResponse
 
 
 
-    public String getContentType(final ClientHttpResponse response) throws IOException {
-
-        if (response.getStatusCode().equals(HttpStatus.NO_CONTENT)) {
-            return null;
-        }
-
+    public String getContentType(final ClientHttpResponse response) {
         final HttpHeaders httpHeaders = getHttpHeaders(response);
-        final MediaType contentType = getMediaType(httpHeaders);
-        return getContentTypeAsString(contentType);
+        return getContentType(httpHeaders);
     }
 
     public String getContentType(final HttpRequest request) {
         final HttpHeaders httpHeaders = getHttpHeaders(request);
+        return getContentType(httpHeaders);
+    }
+
+    private String getContentType(final HttpHeaders httpHeaders) {
         final MediaType contentType = getMediaType(httpHeaders);
 
         if (contentType == null) {

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
@@ -153,7 +153,7 @@ public class DefaultHawaiiRequestResponseLogger implements HawaiiRequestResponse
 
 
 
-    private String getContentType(final ClientHttpResponse response) throws IOException {
+    public String getContentType(final ClientHttpResponse response) throws IOException {
 
         if (response.getStatusCode().equals(HttpStatus.NO_CONTENT)) {
             return null;
@@ -164,7 +164,7 @@ public class DefaultHawaiiRequestResponseLogger implements HawaiiRequestResponse
         return getContentTypeAsString(contentType);
     }
 
-    private String getContentType(final HttpRequest request) {
+    public String getContentType(final HttpRequest request) {
         final HttpHeaders httpHeaders = getHttpHeaders(request);
         final MediaType contentType = getMediaType(httpHeaders);
 

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
@@ -167,6 +167,10 @@ public class DefaultHawaiiRequestResponseLogger implements HawaiiRequestResponse
     private String getContentType(final HttpRequest request) {
         final HttpHeaders httpHeaders = getHttpHeaders(request);
         final MediaType contentType = getMediaType(httpHeaders);
+
+        if (contentType == null) {
+            return null;
+        }
         return getContentTypeAsString(contentType);
     }
 

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
@@ -124,17 +124,17 @@ public class DefaultHawaiiRequestResponseLogger implements HawaiiRequestResponse
         }
     }
 
-    public void logContent(final HttpRequest request, final byte[] body) {
+    private void logContent(final HttpRequest request, final byte[] body) {
         LOGGER.info("Called '{} {}':\n{}", request.getMethod(), request.getURI(),
                 httpRequestResponseLogUtil.createLogString(request.getHeaders(), body));
     }
 
-    public void logContent(final ResettableHttpServletRequest wrappedRequest) throws IOException {
+    private void logContent(final ResettableHttpServletRequest wrappedRequest) throws IOException {
         final String requestUri = wrappedRequest.getRequestURI();
         LOGGER.info("Request is:\n{}", httpRequestResponseLogUtil.formatRequest(requestUri, wrappedRequest));
     }
 
-    public void logContent(final HttpServletRequest servletRequest,
+    private void logContent(final HttpServletRequest servletRequest,
             final ContentCachingWrappedResponse wrappedResponse) throws IOException {
         final int contentLength = wrappedResponse.getContentSize();
         final HttpStatus httpStatus = HttpStatus.valueOf(wrappedResponse.getStatus());
@@ -143,7 +143,7 @@ public class DefaultHawaiiRequestResponseLogger implements HawaiiRequestResponse
                 httpRequestResponseLogUtil.createLogString(servletRequest, wrappedResponse, httpStatus, contentLength));
     }
 
-    public void logContent(final ClientHttpResponse response) throws IOException {
+    private void logContent(final ClientHttpResponse response) throws IOException {
         final HttpStatus statusCode = response.getStatusCode();
         final String statusText = response.getStatusText();
 

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/HawaiiRequestResponseLogger.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/HawaiiRequestResponseLogger.java
@@ -1,0 +1,24 @@
+package org.hawaiiframework.logging.http;
+
+import org.hawaiiframework.logging.web.filter.ContentCachingWrappedResponse;
+import org.hawaiiframework.logging.web.filter.ResettableHttpServletRequest;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+/**
+ * Responsible for logging Http requests and responses.
+ */
+public interface HawaiiRequestResponseLogger {
+
+    void logRequest(HttpRequest request, byte[] body);
+
+    void logRequest(ResettableHttpServletRequest wrappedRequest) throws IOException;
+
+    void logResponse(ClientHttpResponse response) throws IOException;
+
+    void logResponse(HttpServletRequest servletRequest, ContentCachingWrappedResponse wrappedResponse) throws IOException;
+
+}

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/client/LoggingClientHttpRequestInterceptor.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/client/LoggingClientHttpRequestInterceptor.java
@@ -17,28 +17,18 @@ package org.hawaiiframework.logging.http.client;
 
 import org.hawaiiframework.logging.model.AutoCloseableKibanaLogField;
 import org.hawaiiframework.logging.model.KibanaLogFields;
-import org.hawaiiframework.logging.util.HttpRequestResponseLogUtil;
+import org.hawaiiframework.logging.http.HawaiiRequestResponseLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.hawaiiframework.logging.model.KibanaLogCallResultTypes.BACKEND_FAILURE;
-import static org.hawaiiframework.logging.model.KibanaLogCallResultTypes.SUCCESS;
 import static org.hawaiiframework.logging.model.KibanaLogCallResultTypes.TIME_OUT;
-import static org.hawaiiframework.logging.model.KibanaLogFieldNames.CALL_METHOD;
 import static org.hawaiiframework.logging.model.KibanaLogTypeNames.CALL_END;
-import static org.hawaiiframework.logging.model.KibanaLogTypeNames.CALL_REQUEST_BODY;
-import static org.hawaiiframework.logging.model.KibanaLogTypeNames.CALL_RESPONSE_BODY;
 
 /**
  * A logging client http request interceptor.
@@ -55,21 +45,13 @@ public class LoggingClientHttpRequestInterceptor implements ClientHttpRequestInt
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingClientHttpRequestInterceptor.class);
 
-    /**
-     * The configured newline to look for.
-     */
-    private static final String NEW_LINE = System.getProperty("line.separator");
-
-    /**
-     * The request/response log util to use for generating log statements.
-     */
-    private final HttpRequestResponseLogUtil httpRequestResponseLogUtil;
+    private final HawaiiRequestResponseLogger hawaiiRequestResponseLogger;
 
     /**
      * The constructor.
      */
-    public LoggingClientHttpRequestInterceptor(final HttpRequestResponseLogUtil httpRequestResponseLogUtil) {
-        this.httpRequestResponseLogUtil = httpRequestResponseLogUtil;
+    public LoggingClientHttpRequestInterceptor(final HawaiiRequestResponseLogger hawaiiLogger) {
+        this.hawaiiRequestResponseLogger = hawaiiLogger;
     }
 
     /**
@@ -79,9 +61,9 @@ public class LoggingClientHttpRequestInterceptor implements ClientHttpRequestInt
     public ClientHttpResponse intercept(final HttpRequest request, final byte[] body, final ClientHttpRequestExecution execution)
             throws IOException {
         try {
-            logRequest(request, body);
+            hawaiiRequestResponseLogger.logRequest(request, body);
             final ClientHttpResponse response = execution.execute(request, body);
-            logResponse(response);
+            hawaiiRequestResponseLogger.logResponse(response);
             return response;
         } catch (IOException t) {
             KibanaLogFields.callResult(TIME_OUT);
@@ -92,52 +74,6 @@ public class LoggingClientHttpRequestInterceptor implements ClientHttpRequestInt
         }
     }
 
-    private void logRequest(final HttpRequest request, final byte[] body) {
-        try (AutoCloseableKibanaLogField callMethod = KibanaLogFields.tagCloseable(CALL_METHOD, request.getMethodValue());
-                AutoCloseableKibanaLogField kibanaLogField = KibanaLogFields.logType(CALL_REQUEST_BODY)) {
-            LOGGER.info("Called '{} {}':\n{}", request.getMethod(), request.getURI(),
-                    httpRequestResponseLogUtil.createLogString(request.getHeaders(), body));
-        }
-    }
 
-    private void logResponse(final ClientHttpResponse response) throws IOException {
-        final HttpStatus statusCode = response.getStatusCode();
-        final String statusText = response.getStatusText();
-        final String body = readResponseBody(response);
-
-        logResponse(statusCode, statusText, response.getHeaders(), body);
-    }
-
-    private void logResponse(final HttpStatus statusCode, final String statusText, final HttpHeaders headers, final String body) {
-        try (AutoCloseableKibanaLogField kibanaLogField = KibanaLogFields.logType(CALL_RESPONSE_BODY)) {
-            if (statusCode.is2xxSuccessful() || statusCode.is3xxRedirection()) {
-                KibanaLogFields.callResult(SUCCESS);
-            } else {
-                KibanaLogFields.callResult(BACKEND_FAILURE);
-            }
-
-            LOGGER.info("Got response '{} {}':\n{}", statusCode, statusText, httpRequestResponseLogUtil.createLogString(headers, body));
-        }
-    }
-
-    private String readResponseBody(final ClientHttpResponse response) throws IOException {
-        final StringBuilder inputStringBuilder = new StringBuilder();
-
-        return readResponseBody(inputStringBuilder, response);
-    }
-
-    private String readResponseBody(final StringBuilder inputStringBuilder, final ClientHttpResponse response) throws IOException {
-        try (InputStreamReader inputStreamReader = new InputStreamReader(response.getBody(), UTF_8);
-                BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
-            String line = bufferedReader.readLine();
-            while (line != null) {
-                inputStringBuilder.append(line);
-                inputStringBuilder.append(NEW_LINE);
-                line = bufferedReader.readLine();
-            }
-        }
-
-        return inputStringBuilder.toString();
-    }
 
 }

--- a/hawaii-logging/src/test/java/org/hawaiiframework/logging/web/filter/RequestResponseLogFilterTest.java
+++ b/hawaii-logging/src/test/java/org/hawaiiframework/logging/web/filter/RequestResponseLogFilterTest.java
@@ -15,7 +15,8 @@
  */
 package org.hawaiiframework.logging.web.filter;
 
-import org.hawaiiframework.logging.config.filter.RequestResponseLogFilterProperties;
+import org.hawaiiframework.logging.config.HawaiiLoggingConfigurationProperties;
+import org.hawaiiframework.logging.http.DefaultHawaiiRequestResponseLogger;
 import org.hawaiiframework.logging.util.HttpRequestResponseLogUtil;
 import org.junit.Before;
 import org.junit.Test;
@@ -68,9 +69,10 @@ public class RequestResponseLogFilterTest {
         when(request.getQueryString()).thenReturn(A_QUERY_STRING);
 
         final HttpRequestResponseLogUtil httpRequestResponseLogUtil = mock(HttpRequestResponseLogUtil.class);
-        when(httpRequestResponseLogUtil.getRequestUri(request)).thenReturn("some uri");
 
-        filter = new RequestResponseLogFilter(mock(RequestResponseLogFilterProperties.class), httpRequestResponseLogUtil);
+        final DefaultHawaiiRequestResponseLogger logger = new DefaultHawaiiRequestResponseLogger(httpRequestResponseLogUtil, mock(HawaiiLoggingConfigurationProperties.class));
+
+        filter = new RequestResponseLogFilter(logger);
 
 
     }
@@ -88,7 +90,7 @@ public class RequestResponseLogFilterTest {
         final List<Object> allValues = captor.getAllValues();
         String loggedUrl = (String) allValues.get(0);
 
-        assertThat(loggedUrl, is(equalTo("some uri")));
+        assertThat(loggedUrl, is(equalTo(A_REQUEST_URI)));
     }
 
 }


### PR DESCRIPTION
- All http request and response logging is now done in one class
- Allowed content type is used bij the new DefaultHawaiiRequestResponseLogger
- Removed truncation and fallback to file, this should not be done by hawaii framework but by the projects themselves
- Add url base 64 string encoding/decoding.
