### PR TITLE
Also log request if there is no Content-Type specified in the header of the request

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.0.0.M15
+version=3.0.0.M16

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
@@ -60,8 +60,9 @@ public class DefaultHawaiiRequestResponseLogger implements HawaiiRequestResponse
         try (AutoCloseableKibanaLogField callMethod = KibanaLogFields.tagCloseable(CALL_METHOD, request.getMethodValue());
                 AutoCloseableKibanaLogField kibanaLogField = KibanaLogFields.logType(CALL_REQUEST_BODY)) {
 
+            // contentType can be null (a GET for example, doesn't have a Content-Type header usually)
             final String contentType = getContentType(request);
-            if (contentTypeCanBeLogged(contentType)) {
+            if (contentType == null || contentTypeCanBeLogged(contentType)) {
                 LOGGER.info("Called '{} {}':\n{}", request.getMethod(), request.getURI(),
                         httpRequestResponseLogUtil.createLogString(request.getHeaders(), body));
             }


### PR DESCRIPTION
Not all requests (GET for example, have a body, so they also don't have a Content-Type header. The current implementation simply does nog log the request if there is no such header (and a list of allowed content types is defined)

So, if there is no Content-Type header, log the request anyway.