### PR TITLE
Suppress multipart/form-data body logging + Made error handling more flexible

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,3 +18,14 @@ Follow the steps below for publishing a new release.
 * [ ] After the new version is synchronized to Maven Central update the links in 
       https://github.com/hawaiifw/hawaii-framework/blob/gh-pages/_includes/releases.html (in the `gh-pages` branch) to 
       display the new version on http://www.hawaiiframework.org/. 
+
+---
+The closing and releasing of repositories can be done via the nexus plugin.
+
+```
+``./gradlew -Dorg.gradle.internal.publish.checksums.insecure=true \
+  -Psigning.keyId=0x12345678 \ 
+  -Psigning.password=very-secret \ 
+  -Psigning.secretKeyRingFile=$(pwd)/tmp/private.key.gpg 
+  publishToSonatype closeAndReleaseStagingRepository
+```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=6.0.0.M2-SNAPSHOT
+version=6.0.0.M3-SNAPSHOT

--- a/hawaii-autoconfigure/build.gradle.kts
+++ b/hawaii-autoconfigure/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
     compileOnly("org.springframework:spring-webmvc")
     compileOnly("org.springframework.data:spring-data-redis")
     compileOnly("org.springframework.security:spring-security-core")
+    compileOnly("jakarta.validation:jakarta.validation-api:3.0.2")
+
 }
 
 tasks.withType<JavaCompile> {

--- a/hawaii-autoconfigure/build.gradle.kts
+++ b/hawaii-autoconfigure/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     compileOnly("jakarta.servlet:jakarta.servlet-api")
     compileOnly("org.springframework:spring-webmvc")
     compileOnly("org.springframework.data:spring-data-redis")
+    compileOnly("org.springframework.security:spring-security-core")
 }
 
 tasks.withType<JavaCompile> {

--- a/hawaii-autoconfigure/src/main/java/org/hawaiiframework/boot/autoconfigure/rest/HawaiiRestAutoConfiguration.java
+++ b/hawaii-autoconfigure/src/main/java/org/hawaiiframework/boot/autoconfigure/rest/HawaiiRestAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.hawaiiframework.boot.autoconfigure.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.ValidationException;
 import org.hawaiiframework.converter.ModelConverter;
 import org.hawaiiframework.validation.ValidationError;
 import org.hawaiiframework.web.exception.ApiErrorResponseEnricher;
@@ -26,6 +27,7 @@ import org.hawaiiframework.web.exception.ErrorResponseEntityBuilder;
 import org.hawaiiframework.web.exception.ErrorResponseStatusEnricher;
 import org.hawaiiframework.web.exception.ExceptionResponseFactory;
 import org.hawaiiframework.web.exception.HawaiiResponseEntityExceptionHandler;
+import org.hawaiiframework.web.exception.JakartaValidationsEntityExceptionHandler;
 import org.hawaiiframework.web.exception.MethodArgumentNotValidResponseEnricher;
 import org.hawaiiframework.web.exception.RequestInfoErrorResponseEnricher;
 import org.hawaiiframework.web.exception.SpringSecurityResponseEntityExceptionHandler;
@@ -48,7 +50,7 @@ import java.util.List;
  * @author Marcel Overdijk
  * @since 2.0.0
  */
-@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
 @Configuration
 @ConditionalOnWebApplication
 public class HawaiiRestAutoConfiguration {
@@ -101,6 +103,7 @@ public class HawaiiRestAutoConfiguration {
             final ErrorResponseEntityBuilder errorResponseEntityBuilder) {
         return new HawaiiResponseEntityExceptionHandler(errorResponseEntityBuilder);
     }
+
     /**
      * Create a Spring Security response exception handler.
      *
@@ -112,6 +115,19 @@ public class HawaiiRestAutoConfiguration {
             final ErrorResponseEntityBuilder errorResponseEntityBuilder) {
         return new SpringSecurityResponseEntityExceptionHandler(errorResponseEntityBuilder);
     }
+
+    /**
+     * Create a Spring Security response exception handler.
+     *
+     * @return The Spring Security response exception handler bean.
+     */
+    @ConditionalOnClass(ValidationException.class)
+    @Bean
+    public JakartaValidationsEntityExceptionHandler jakartaValidationsEntityExceptionHandler(
+            final ErrorResponseEntityBuilder errorResponseEntityBuilder) {
+        return new JakartaValidationsEntityExceptionHandler(errorResponseEntityBuilder);
+    }
+
     /**
      * Create an error response status enricher.
      *

--- a/hawaii-autoconfigure/src/main/java/org/hawaiiframework/boot/autoconfigure/rest/HawaiiRestAutoConfiguration.java
+++ b/hawaii-autoconfigure/src/main/java/org/hawaiiframework/boot/autoconfigure/rest/HawaiiRestAutoConfiguration.java
@@ -17,27 +17,54 @@
 package org.hawaiiframework.boot.autoconfigure.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hawaiiframework.converter.ModelConverter;
+import org.hawaiiframework.validation.ValidationError;
+import org.hawaiiframework.web.exception.ApiErrorResponseEnricher;
 import org.hawaiiframework.web.exception.DefaultExceptionResponseFactory;
+import org.hawaiiframework.web.exception.ErrorResponseEnricher;
+import org.hawaiiframework.web.exception.ErrorResponseEntityBuilder;
+import org.hawaiiframework.web.exception.ErrorResponseStatusEnricher;
 import org.hawaiiframework.web.exception.ExceptionResponseFactory;
 import org.hawaiiframework.web.exception.HawaiiResponseEntityExceptionHandler;
+import org.hawaiiframework.web.exception.MethodArgumentNotValidResponseEnricher;
+import org.hawaiiframework.web.exception.RequestInfoErrorResponseEnricher;
+import org.hawaiiframework.web.exception.SpringSecurityResponseEntityExceptionHandler;
+import org.hawaiiframework.web.exception.ValidationErrorResponseEnricher;
 import org.hawaiiframework.web.resource.ObjectErrorResourceAssembler;
+import org.hawaiiframework.web.resource.ValidationErrorResource;
 import org.hawaiiframework.web.resource.ValidationErrorResourceAssembler;
 import org.hawaiiframework.web.util.HostResolver;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.ObjectError;
+
+import java.util.List;
 
 /**
  * @author Marcel Overdijk
  * @since 2.0.0
  */
+@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 @Configuration
 @ConditionalOnWebApplication
 public class HawaiiRestAutoConfiguration {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    /**
+     * Create a host resolver bean.
+     *
+     * @return The host resolver bean.
+     */
+    @Bean
+    public HostResolver hostResolver() {
+        return new HostResolver();
+    }
 
     /**
      * Create an object error resource assembler.
@@ -47,6 +74,73 @@ public class HawaiiRestAutoConfiguration {
     @Bean
     public ObjectErrorResourceAssembler objectErrorResourceAssembler() {
         return new ObjectErrorResourceAssembler(objectMapper);
+    }
+
+    /**
+     * Create an exception response factory.
+     *
+     * @return The exception response factory bean.
+     */
+    @Bean
+    public ExceptionResponseFactory exceptionResponseFactory() {
+        return new DefaultExceptionResponseFactory();
+    }
+
+    @Bean
+    public ErrorResponseEntityBuilder errorResponseEntityBuilder(final List<ErrorResponseEnricher> errorResponseEnrichers) {
+        return new ErrorResponseEntityBuilder(exceptionResponseFactory(), errorResponseEnrichers);
+    }
+
+    /**
+     * Create a Hawaii response exception handler.
+     *
+     * @return The Hawaii response exception handler bean.
+     */
+    @Bean
+    public HawaiiResponseEntityExceptionHandler hawaiiResponseEntityExceptionHandler(
+            final ErrorResponseEntityBuilder errorResponseEntityBuilder) {
+        return new HawaiiResponseEntityExceptionHandler(errorResponseEntityBuilder);
+    }
+    /**
+     * Create a Spring Security response exception handler.
+     *
+     * @return The Spring Security response exception handler bean.
+     */
+    @ConditionalOnClass(AccessDeniedException.class)
+    @Bean
+    public SpringSecurityResponseEntityExceptionHandler springSecurityResponseEntityExceptionHandler(
+            final ErrorResponseEntityBuilder errorResponseEntityBuilder) {
+        return new SpringSecurityResponseEntityExceptionHandler(errorResponseEntityBuilder);
+    }
+    /**
+     * Create an error response status enricher.
+     *
+     * @return The error response status enricher bean.
+     */
+    @Bean
+    public ErrorResponseStatusEnricher errorResponseStatusEnricher() {
+        return new ErrorResponseStatusEnricher();
+    }
+
+    /**
+     * Create a request info error response enricher.
+     *
+     * @return The request info error response enricher bean.
+     */
+    @Bean
+    public RequestInfoErrorResponseEnricher requestInfoErrorResponseEnricher() {
+        return new RequestInfoErrorResponseEnricher();
+    }
+
+    /**
+     * Create a method argument not valid response enricher.
+     *
+     * @return The method argument not valid response enricher bean.
+     */
+    @Bean
+    public MethodArgumentNotValidResponseEnricher methodArgumentNotValidResponseEnricher(
+            final ModelConverter<ObjectError, ValidationErrorResource> objectErrorResourceAssembler) {
+        return new MethodArgumentNotValidResponseEnricher(objectErrorResourceAssembler);
     }
 
     /**
@@ -60,35 +154,23 @@ public class HawaiiRestAutoConfiguration {
     }
 
     /**
-     * Create an exception response factory.
+     * Create a validation error response enricher.
      *
-     * @return The exception response factory bean.
+     * @return The validation error response enricher bean.
      */
     @Bean
-    public ExceptionResponseFactory exceptionResponseFactory() {
-        return new DefaultExceptionResponseFactory();
+    public ValidationErrorResponseEnricher validationErrorResponseEnricher(
+            final ModelConverter<ValidationError, ValidationErrorResource> validationErrorResourceAssembler) {
+        return new ValidationErrorResponseEnricher(validationErrorResourceAssembler);
     }
 
     /**
-     * Create a Hawaii response exception handler.
+     * Create an api error response enricher.
      *
-     * @return The Hawaii response exception handler bean.
+     * @return The api error response enricher bean.
      */
     @Bean
-    public HawaiiResponseEntityExceptionHandler hawaiiResponseEntityExceptionHandler() {
-        return new HawaiiResponseEntityExceptionHandler(
-                objectErrorResourceAssembler(),
-                validationErrorResourceAssembler(),
-                exceptionResponseFactory());
-    }
-
-    /**
-     * Create a host resolver bean.
-     *
-     * @return The host resolver bean.
-     */
-    @Bean
-    public HostResolver hostResolver() {
-        return new HostResolver();
+    public ApiErrorResponseEnricher apiErrorResponseEnricher() {
+        return new ApiErrorResponseEnricher();
     }
 }

--- a/hawaii-autoconfigure/src/main/resources/config/hawaii-framework.properties
+++ b/hawaii-autoconfigure/src/main/resources/config/hawaii-framework.properties
@@ -19,6 +19,8 @@ hawaii.async.configuration=${ASYNC_CONFIG:./config/async-config.yml}
 #  text/plain,\
 #  text/xml
 
+#hawaii.logging.body-excluded-content-types=multipart/form-data
+
 #hawaii.logging.exclude-paths=/actuator/*
 
 #hawaii.logging.fields-to-mask=password,\

--- a/hawaii-autoconfigure/src/main/resources/config/hawaii-framework.yml
+++ b/hawaii-autoconfigure/src/main/resources/config/hawaii-framework.yml
@@ -18,8 +18,8 @@ hawaii:
     enabled: true
     init:
   logging:
-    # For console logging, the allowed content types, empty means allow all,
-    # including binary files, so not a good idea.
+    # All allowed-content types will be fully logged, this means the request / response headers and the body.
+    # The body can be suppressed by configuring the content-type in the `body-excluded-content-types` property.
     allowed-content-types:
       - application/json
       - application/graphql+json
@@ -33,7 +33,7 @@ hawaii:
       - text/plain
       - text/xml
     # do not log body
-    suppressed-content-types:
+    body-excluded-content-types:
       - multipart/form-data
     exclude-paths:
       - /actuator/*
@@ -41,6 +41,8 @@ hawaii:
       - password
       - keyPassphrase
     filters:
+      # The idea is that Spring Boot (6) supplies micrometer observability, that includes W3C tracing,
+      # so a lot of "old skool" trace headers are disabled by default (since 2.x).
       kibana-log-cleanup:
         # Must set explicitly to false if not required. If the property is not present, the default is "enabled = true".
         enabled: true
@@ -66,7 +68,7 @@ hawaii:
         http-header: ${OPEN_TELEMETRY_TRACE_ID_HEADER:traceid}
       open-telemetry-tracing-response:
         # Must set explicitly to false if not required. If the property is not present, the default is "enabled = true".
-        enabled: true
+        enabled: false
         order: -1000
         http-header: ${OPEN_TELEMETRY_TRACE_ID_HEADER:traceid}
       oidc:
@@ -75,26 +77,26 @@ hawaii:
         order: -900
       client-ip-log:
         # Must set explicitly to false if not required. If the property is not present, the default is "enabled = true".
-        enabled: true
+        enabled: false
         order: -800
         http-header: X-Hawaii-Frontend-IP-Address
       transaction-type:
         # Must set explicitly to false if not required. If the property is not present, the default is "enabled = true".
-        enabled: true
+        enabled: false
         order: -700
       business-transaction-id:
         # Must set explicitly to false if not required. If the property is not present, the default is "enabled = true".
-        enabled: true
+        enabled: false
         order: -600
         http-header: X-Hawaii-Business-Tx-Id
       transaction-id:
         # Must set explicitly to false if not required. If the property is not present, the default is "enabled = true".
-        enabled: true
+        enabled: false
         order: -500
         http-header: X-Hawaii-Tx-Id
       request-id:
         # Must set explicitly to false if not required. If the property is not present, the default is "enabled = true".
-        enabled: true
+        enabled: false
         order: -400
         http-header: X-Hawaii-Request-Id
       request-response:
@@ -103,7 +105,7 @@ hawaii:
         order: -300
       user-details:
         # Must set explicitly to false if not required. If the property is not present, the default is "enabled = true".
-        enabled: true
+        enabled: false
         order: 200
   time:
     # Must set explicitly to false if not required. If the property is not present, the default is "enabled = true".

--- a/hawaii-autoconfigure/src/main/resources/config/hawaii-framework.yml
+++ b/hawaii-autoconfigure/src/main/resources/config/hawaii-framework.yml
@@ -32,6 +32,9 @@ hawaii:
       - multipart/form-data
       - text/plain
       - text/xml
+    # do not log body
+    suppressed-content-types:
+      - multipart/form-data
     exclude-paths:
       - /actuator/*
     fields-to-mask:

--- a/hawaii-autoconfigure/src/main/resources/config/hawaii-framework.yml
+++ b/hawaii-autoconfigure/src/main/resources/config/hawaii-framework.yml
@@ -42,7 +42,7 @@ hawaii:
       - keyPassphrase
     filters:
       # The idea is that Spring Boot (6) supplies micrometer observability, that includes W3C tracing,
-      # so a lot of "old skool" trace headers are disabled by default (since 2.x).
+      # so a lot of "old skool" trace headers are disabled by default (since 6.0.0).
       kibana-log-cleanup:
         # Must set explicitly to false if not required. If the property is not present, the default is "enabled = true".
         enabled: true

--- a/hawaii-core/src/main/java/org/hawaiiframework/web/exception/ErrorResponseEntityBuilder.java
+++ b/hawaii-core/src/main/java/org/hawaiiframework/web/exception/ErrorResponseEntityBuilder.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawaiiframework.web.exception;
+
+import org.hawaiiframework.web.resource.ErrorResponseResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class creates proper HTTP response bodies for exceptions.
+ *
+ * @since 6.0.0
+ */
+@SuppressWarnings("checkstyle:ClassFanOutComplexity")
+public class ErrorResponseEntityBuilder {
+    private final ExceptionResponseFactory exceptionResponseFactory;
+    private final Set<ErrorResponseEnricher> errorResponseEnrichers = new HashSet<>();
+
+    public ErrorResponseEntityBuilder(final ExceptionResponseFactory exceptionResponseFactory,
+            final List<ErrorResponseEnricher> errorResponseEnrichers) {
+        this.exceptionResponseFactory =
+                requireNonNull(exceptionResponseFactory, "'exceptionResponseFactory' must not be null");
+        if (errorResponseEnrichers != null) {
+            this.errorResponseEnrichers.addAll(errorResponseEnrichers);
+        }
+    }
+
+    /**
+     * Builds a meaningful response body for the given throwable, HTTP status and request.
+     * <p>
+     * This method constructs an {@link ErrorResponseResource} using {@link #exceptionResponseFactory} and then applies
+     * the error response enrichers returned from {@link #getResponseEnrichers()} to complete the response.
+     *
+     * @param throwable the exception
+     * @param status    the HTTP status
+     * @param request   the current request
+     * @return an error response
+     */
+    public ErrorResponseResource buildErrorResponseBody(
+            final Throwable throwable,
+            final HttpStatus status,
+            final WebRequest request) {
+        final ErrorResponseResource resource = exceptionResponseFactory.create(throwable);
+        getResponseEnrichers().forEach(enricher -> enricher.enrich(resource, request, status));
+        return resource;
+    }
+
+    /**
+     * Registers a {@link ErrorResponseEnricher}.
+     *
+     * @param errorResponseEnricher the error response enricher
+     */
+    public void addResponseEnricher(final ErrorResponseEnricher errorResponseEnricher) {
+        errorResponseEnrichers.add(errorResponseEnricher);
+    }
+
+    /**
+     * De-registers a {@link ErrorResponseEnricher}.
+     *
+     * @param errorResponseEnricher the error response enricher
+     */
+    public void removeResponseEnricher(final ErrorResponseEnricher errorResponseEnricher) {
+        errorResponseEnrichers.remove(errorResponseEnricher);
+    }
+
+    /**
+     * Returns a collection of registered response enrichers.
+     *
+     * @return the response enrichers
+     */
+    public Collection<ErrorResponseEnricher> getResponseEnrichers() {
+        return new HashSet<>(errorResponseEnrichers);
+    }
+}

--- a/hawaii-core/src/main/java/org/hawaiiframework/web/exception/HawaiiResponseEntityExceptionHandler.java
+++ b/hawaii-core/src/main/java/org/hawaiiframework/web/exception/HawaiiResponseEntityExceptionHandler.java
@@ -21,6 +21,7 @@ import org.hawaiiframework.validation.ValidationException;
 import org.hawaiiframework.web.resource.ErrorResponseResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -44,6 +45,7 @@ import static org.springframework.http.HttpHeaders.EMPTY;
  * @author Richard den Adel
  * @since 2.0.0
  */
+@Order
 @ControllerAdvice
 public class HawaiiResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
 

--- a/hawaii-core/src/main/java/org/hawaiiframework/web/exception/HawaiiResponseEntityExceptionHandler.java
+++ b/hawaii-core/src/main/java/org/hawaiiframework/web/exception/HawaiiResponseEntityExceptionHandler.java
@@ -16,22 +16,16 @@
 
 package org.hawaiiframework.web.exception;
 
-import org.hawaiiframework.converter.ModelConverter;
 import org.hawaiiframework.exception.ApiException;
-import org.hawaiiframework.validation.ValidationError;
 import org.hawaiiframework.validation.ValidationException;
 import org.hawaiiframework.web.resource.ErrorResponseResource;
-import org.hawaiiframework.web.resource.ValidationErrorResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.NonNull;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -39,25 +33,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import static java.util.Objects.requireNonNull;
 import static org.springframework.http.HttpHeaders.EMPTY;
 
 /**
  * This class creates proper HTTP response bodies for exceptions.
- * <p>
- * In this implementation, the response enrichers are stored in a map, with the class name as key. This means that any enricher can
- * be stored only once. Also, enrichers are not ordered. Subclasses may implement another mechanism if required. This would mean that
- * the following methods would need to be overwritten:
- * <ul>
- * <li>{@link #addResponseEnricher(ErrorResponseEnricher)}</li>
- * <li>{@link #removeResponseEnricher(ErrorResponseEnricher)} (optionally)</li>
- * <li>{@link #configureResponseEnrichers()}</li>
- * <li>{@link #getResponseEnrichers()}</li>
- * </ul>
  *
  * @author Marcel Overdijk
  * @author Ivan Melotte
@@ -65,31 +44,15 @@ import static org.springframework.http.HttpHeaders.EMPTY;
  * @author Richard den Adel
  * @since 2.0.0
  */
-@SuppressWarnings("checkstyle:ClassFanOutComplexity")
 @ControllerAdvice
-public class HawaiiResponseEntityExceptionHandler extends ResponseEntityExceptionHandler implements InitializingBean {
+public class HawaiiResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private final ModelConverter<ObjectError, ValidationErrorResource> objectErrorResourceAssembler;
-    private final ModelConverter<ValidationError, ValidationErrorResource> validationErrorResourceAssembler;
-    private final ExceptionResponseFactory exceptionResponseFactory;
-    private final Map<String, ErrorResponseEnricher> errorResponseEnrichers = new ConcurrentHashMap<>();
+    private final ErrorResponseEntityBuilder errorResponseEntityBuilder;
 
-    public HawaiiResponseEntityExceptionHandler(
-            final ModelConverter<ObjectError, ValidationErrorResource> objectErrorResourceAssembler,
-            final ModelConverter<ValidationError, ValidationErrorResource> validationErrorResourceAssembler,
-            final ExceptionResponseFactory exceptionResponseFactory) {
-        this.objectErrorResourceAssembler = objectErrorResourceAssembler;
-        this.validationErrorResourceAssembler =
-                requireNonNull(validationErrorResourceAssembler, "'validationErrorResourceAssembler' must not be null");
-        this.exceptionResponseFactory =
-                requireNonNull(exceptionResponseFactory, "'exceptionResponseFactory' must not be null");
-    }
-
-    @Override
-    public void afterPropertiesSet() {
-        configureResponseEnrichers();
+    public HawaiiResponseEntityExceptionHandler(final ErrorResponseEntityBuilder errorResponseEntityBuilder) {
+        this.errorResponseEntityBuilder = errorResponseEntityBuilder;
     }
 
     /**
@@ -130,22 +93,6 @@ public class HawaiiResponseEntityExceptionHandler extends ResponseEntityExceptio
             @NonNull final WebRequest request) {
 
         return handleExceptionInternal(ex, buildErrorResponseBody(ex, HttpStatus.valueOf(status.value()), request), EMPTY, status, request);
-    }
-
-    /**
-     * Handles {@code AccessDeniedException} instances.
-     * <p>
-     * The response status is: 403 Forbidden.
-     *
-     * @param ex      the exception
-     * @param request the current request
-     * @return a response entity reflecting the current exception
-     */
-    @ExceptionHandler(AccessDeniedException.class)
-    @ResponseBody
-    public ResponseEntity<Object> accessDeniedException(final AccessDeniedException ex, final WebRequest request) {
-        final HttpStatus status = HttpStatus.FORBIDDEN;
-        return handleExceptionInternal(ex, buildErrorResponseBody(ex, status, request), EMPTY, status, request);
     }
 
     /**
@@ -195,81 +142,7 @@ public class HawaiiResponseEntityExceptionHandler extends ResponseEntityExceptio
         return ResponseEntity.status(status).body(buildErrorResponseBody(t, status, request));
     }
 
-    /**
-     * Builds a meaningful response body for the given throwable, HTTP status and request.
-     * <p>
-     * This method constructs an {@link ErrorResponseResource} using {@link #exceptionResponseFactory} and then applies
-     * the error response enrichers returned from {@link #getResponseEnrichers()} to complete the response.
-     *
-     * @param throwable the exception
-     * @param status    the HTTP status
-     * @param request   the current request
-     * @return an error response
-     */
-    protected ErrorResponseResource buildErrorResponseBody(
-            final Throwable throwable,
-            final HttpStatus status,
-            final WebRequest request) {
-        final ErrorResponseResource resource = exceptionResponseFactory.create(throwable);
-        getResponseEnrichers().forEach(enricher -> enricher.enrich(resource, request, status));
-        return resource;
-    }
-
-    /**
-     * Registers a {@link ErrorResponseEnricher}.
-     *
-     * @param errorResponseEnricher the error response enricher
-     */
-    protected void addResponseEnricher(final ErrorResponseEnricher errorResponseEnricher) {
-        errorResponseEnrichers.put(errorResponseEnricher.getClass().getName(), errorResponseEnricher);
-    }
-
-    /**
-     * De-registers a {@link ErrorResponseEnricher}.
-     *
-     * @param errorResponseEnricher the error response enricher
-     */
-    protected void removeResponseEnricher(final ErrorResponseEnricher errorResponseEnricher) {
-        errorResponseEnrichers.remove(errorResponseEnricher.getClass().getName());
-    }
-
-    /**
-     * De-registers a {@link ErrorResponseEnricher} based on its class name.
-     *
-     * @param className the class name of the {@link ErrorResponseEnricher} to remove
-     */
-    protected void removeResponseEnricher(final Class<? extends ErrorResponseEnricher> className) {
-        errorResponseEnrichers.remove(className.getName());
-    }
-
-    /**
-     * Configures the error response enrichers.
-     *
-     * <p>Subclasses may override this method to remove existing or add additional listeners,
-     * using {@link #addResponseEnricher(ErrorResponseEnricher)} and {@link #removeResponseEnricher(ErrorResponseEnricher)}.</p>
-     * <p>
-     * The default implementation adds the following listeners:
-     * <ul>
-     * <li>{@link ErrorResponseStatusEnricher}</li>
-     * <li>{@link RequestInfoErrorResponseEnricher}</li>
-     * <li>{@link ValidationErrorResponseEnricher}</li>
-     * <li>{@link ApiErrorResponseEnricher}</li>
-     * </ul>
-     */
-    protected void configureResponseEnrichers() {
-        addResponseEnricher(new ErrorResponseStatusEnricher());
-        addResponseEnricher(new RequestInfoErrorResponseEnricher());
-        addResponseEnricher(new MethodArgumentNotValidResponseEnricher(objectErrorResourceAssembler));
-        addResponseEnricher(new ValidationErrorResponseEnricher(validationErrorResourceAssembler));
-        addResponseEnricher(new ApiErrorResponseEnricher());
-    }
-
-    /**
-     * Returns a collection of registered response enrichers.
-     *
-     * @return the response enrichers
-     */
-    protected Collection<ErrorResponseEnricher> getResponseEnrichers() {
-        return errorResponseEnrichers.values();
+    private ErrorResponseResource buildErrorResponseBody(final Throwable throwable, final HttpStatus status, final WebRequest request) {
+        return errorResponseEntityBuilder.buildErrorResponseBody(throwable, status, request);
     }
 }

--- a/hawaii-core/src/main/java/org/hawaiiframework/web/exception/JakartaValidationsEntityExceptionHandler.java
+++ b/hawaii-core/src/main/java/org/hawaiiframework/web/exception/JakartaValidationsEntityExceptionHandler.java
@@ -20,7 +20,6 @@ import org.hawaiiframework.web.resource.ErrorResponseResource;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -36,27 +35,28 @@ import static org.springframework.http.HttpHeaders.EMPTY;
  */
 @Order(0)
 @ControllerAdvice
-public class SpringSecurityResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+public class JakartaValidationsEntityExceptionHandler extends ResponseEntityExceptionHandler {
 
     private final ErrorResponseEntityBuilder errorResponseEntityBuilder;
 
-    public SpringSecurityResponseEntityExceptionHandler(final ErrorResponseEntityBuilder errorResponseEntityBuilder) {
+    public JakartaValidationsEntityExceptionHandler(final ErrorResponseEntityBuilder errorResponseEntityBuilder) {
         this.errorResponseEntityBuilder = errorResponseEntityBuilder;
     }
+
     /**
-     * Handles {@code AccessDeniedException} instances.
+     * Handles {@code ValidationException} instances.
      * <p>
-     * The response status is: 403 Forbidden.
+     * The response status is: 400 Bad Request.
      *
-     * @param ex      the exception
+     * @param e       the exception
      * @param request the current request
      * @return a response entity reflecting the current exception
      */
-    @ExceptionHandler(AccessDeniedException.class)
+    @ExceptionHandler(jakarta.validation.ValidationException.class)
     @ResponseBody
-    public ResponseEntity<Object> accessDeniedException(final AccessDeniedException ex, final WebRequest request) {
-        final HttpStatus status = HttpStatus.FORBIDDEN;
-        return handleExceptionInternal(ex, buildErrorResponseBody(ex, status, request), EMPTY, status, request);
+    public ResponseEntity<Object> handleValidationException(final jakarta.validation.ValidationException e, final WebRequest request) {
+        final HttpStatus status = HttpStatus.BAD_REQUEST;
+        return handleExceptionInternal(e, buildErrorResponseBody(e, status, request), EMPTY, status, request);
     }
 
     private ErrorResponseResource buildErrorResponseBody(final Throwable throwable, final HttpStatus status, final WebRequest request) {

--- a/hawaii-core/src/main/java/org/hawaiiframework/web/exception/SpringSecurityResponseEntityExceptionHandler.java
+++ b/hawaii-core/src/main/java/org/hawaiiframework/web/exception/SpringSecurityResponseEntityExceptionHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawaiiframework.web.exception;
+
+import org.hawaiiframework.web.resource.ErrorResponseResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import static org.springframework.http.HttpHeaders.EMPTY;
+
+/**
+ * This class creates proper HTTP response bodies for exceptions.
+ *
+ * @author Marcel Overdijk
+ * @author Ivan Melotte
+ * @author Paul Klos
+ * @author Richard den Adel
+ * @since 2.0.0
+ */
+@ControllerAdvice
+public class SpringSecurityResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private final ErrorResponseEntityBuilder errorResponseEntityBuilder;
+
+    public SpringSecurityResponseEntityExceptionHandler(final ErrorResponseEntityBuilder errorResponseEntityBuilder) {
+        this.errorResponseEntityBuilder = errorResponseEntityBuilder;
+    }
+    /**
+     * Handles {@code AccessDeniedException} instances.
+     * <p>
+     * The response status is: 403 Forbidden.
+     *
+     * @param ex      the exception
+     * @param request the current request
+     * @return a response entity reflecting the current exception
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseBody
+    public ResponseEntity<Object> accessDeniedException(final AccessDeniedException ex, final WebRequest request) {
+        final HttpStatus status = HttpStatus.FORBIDDEN;
+        return handleExceptionInternal(ex, buildErrorResponseBody(ex, status, request), EMPTY, status, request);
+    }
+
+    private ErrorResponseResource buildErrorResponseBody(final Throwable throwable, final HttpStatus status, final WebRequest request) {
+        return errorResponseEntityBuilder.buildErrorResponseBody(throwable, status, request);
+    }
+}

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/FilterVoter.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/FilterVoter.java
@@ -64,7 +64,7 @@ public class FilterVoter {
         Boolean isEnabled = (Boolean) request.getAttribute(getAttributeName());
         LOGGER.trace("Got '{}' from attribute.", isEnabled);
         if (isEnabled == null) {
-            final boolean mediaTypeAllowed = mediaTypeVoter.mediaTypeAllowed(request.getContentType());
+            final boolean mediaTypeAllowed = mediaTypeVoter.mediaTypeMatches(request.getContentType());
             final boolean requestAllowed = requestVoter.allowed(request);
             isEnabled = mediaTypeAllowed && requestAllowed;
             request.setAttribute(getAttributeName(), isEnabled);

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfiguration.java
@@ -41,7 +41,6 @@ import org.springframework.context.annotation.Import;
  * @since 2.0.0
  */
 @Configuration
-//@EnableConfigurationProperties(HawaiiLoggingConfigurationProperties.class)
 @Import({CxfLoggingConfiguration.class, DataSourceProxyConfiguration.class, HawaiiLoggingFilterConfiguration.class,
     ScheduledConfiguration.class, StatementLoggerQueryExecutionListenerConfiguration.class})
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
@@ -134,7 +133,7 @@ public class HawaiiLoggingConfiguration {
             final HttpRequestResponseBodyLogUtil bodyLogUtil,
             final HttpRequestResponseDebugLogUtil debugLogUtil,
             final MediaTypeVoter mediaTypeVoter,
-            @Qualifier("suppressedMediaTypeVoter") final MediaTypeVoter suppressedMediaTypeVoter) {
+            @Qualifier("bodyExcludedMediaTypeVoter") final MediaTypeVoter suppressedMediaTypeVoter) {
         return new DefaultHawaiiRequestResponseLogger(headersLogUtil, bodyLogUtil, debugLogUtil,
                 mediaTypeVoter, suppressedMediaTypeVoter);
     }
@@ -153,8 +152,8 @@ public class HawaiiLoggingConfiguration {
 
     @Bean
     @RefreshScope
-    public MediaTypeVoter suppressedMediaTypeVoter(final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
-        return new MediaTypeVoter(hawaiiLoggingConfigurationProperties.getSuppressedContentTypes(), false);
+    public MediaTypeVoter bodyExcludedMediaTypeVoter(final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
+        return new MediaTypeVoter(hawaiiLoggingConfigurationProperties.getBodyExcludedContentTypes(), false);
     }
 
     /**

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfiguration.java
@@ -23,6 +23,7 @@ import org.hawaiiframework.logging.util.HttpRequestResponseDebugLogUtil;
 import org.hawaiiframework.logging.util.HttpRequestResponseHeadersLogUtil;
 import org.hawaiiframework.logging.util.PasswordMaskerUtil;
 import org.hawaiiframework.sql.DataSourceProxyConfiguration;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -132,9 +133,10 @@ public class HawaiiLoggingConfiguration {
             final HttpRequestResponseHeadersLogUtil headersLogUtil,
             final HttpRequestResponseBodyLogUtil bodyLogUtil,
             final HttpRequestResponseDebugLogUtil debugLogUtil,
-            final MediaTypeVoter mediaTypeVoter) {
+            final MediaTypeVoter mediaTypeVoter,
+            @Qualifier("suppressedMediaTypeVoter") final MediaTypeVoter suppressedMediaTypeVoter) {
         return new DefaultHawaiiRequestResponseLogger(headersLogUtil, bodyLogUtil, debugLogUtil,
-                mediaTypeVoter);
+                mediaTypeVoter, suppressedMediaTypeVoter);
     }
 
     /**
@@ -146,7 +148,13 @@ public class HawaiiLoggingConfiguration {
     @Bean
     @RefreshScope
     public MediaTypeVoter mediaTypeVoter(final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
-        return new MediaTypeVoter(hawaiiLoggingConfigurationProperties);
+        return new MediaTypeVoter(hawaiiLoggingConfigurationProperties.getAllowedContentTypes(), true);
+    }
+
+    @Bean
+    @RefreshScope
+    public MediaTypeVoter suppressedMediaTypeVoter(final HawaiiLoggingConfigurationProperties hawaiiLoggingConfigurationProperties) {
+        return new MediaTypeVoter(hawaiiLoggingConfigurationProperties.getSuppressedContentTypes(), false);
     }
 
     /**

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfiguration.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfiguration.java
@@ -133,9 +133,9 @@ public class HawaiiLoggingConfiguration {
             final HttpRequestResponseBodyLogUtil bodyLogUtil,
             final HttpRequestResponseDebugLogUtil debugLogUtil,
             final MediaTypeVoter mediaTypeVoter,
-            @Qualifier("bodyExcludedMediaTypeVoter") final MediaTypeVoter suppressedMediaTypeVoter) {
+            @Qualifier("bodyExcludedMediaTypeVoter") final MediaTypeVoter bodyExcludedMediaTypeVoter) {
         return new DefaultHawaiiRequestResponseLogger(headersLogUtil, bodyLogUtil, debugLogUtil,
-                mediaTypeVoter, suppressedMediaTypeVoter);
+                mediaTypeVoter, bodyExcludedMediaTypeVoter);
     }
 
     /**

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfigurationProperties.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfigurationProperties.java
@@ -33,7 +33,7 @@ public class HawaiiLoggingConfigurationProperties {
             parseMediaType("text/plain"),
             parseMediaType("text/xml"));
 
-    private List<MediaType> suppressedContentTypes = List.of(MediaType.MULTIPART_FORM_DATA);
+    private List<MediaType> bodyExcludedContentTypes = List.of(MediaType.MULTIPART_FORM_DATA);
 
     private List<PathDefinition> excludePaths = List.of(new PathDefinition("/actuator/*"));
 
@@ -93,11 +93,11 @@ public class HawaiiLoggingConfigurationProperties {
         this.excludePaths = excludePaths;
     }
 
-    public List<MediaType> getSuppressedContentTypes() {
-        return suppressedContentTypes;
+    public List<MediaType> getBodyExcludedContentTypes() {
+        return bodyExcludedContentTypes;
     }
 
-    public void setSuppressedContentTypes(final List<MediaType> suppressedContentTypes) {
-        this.suppressedContentTypes = suppressedContentTypes;
+    public void setBodyExcludedContentTypes(final List<MediaType> bodyExcludedContentTypes) {
+        this.bodyExcludedContentTypes = bodyExcludedContentTypes;
     }
 }

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfigurationProperties.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/HawaiiLoggingConfigurationProperties.java
@@ -33,10 +33,10 @@ public class HawaiiLoggingConfigurationProperties {
             parseMediaType("text/plain"),
             parseMediaType("text/xml"));
 
-    // @Value("${" + CONFIG_PREFIX + ".exclude-paths}")
+    private List<MediaType> suppressedContentTypes = List.of(MediaType.MULTIPART_FORM_DATA);
+
     private List<PathDefinition> excludePaths = List.of(new PathDefinition("/actuator/*"));
 
-    // @Value("${" + CONFIG_PREFIX + ".fields-to-mask}")
     private List<String> fieldsToMask = List.of("password", "keyPassphrase", "client_secret", "secret");
 
     /**
@@ -93,4 +93,11 @@ public class HawaiiLoggingConfigurationProperties {
         this.excludePaths = excludePaths;
     }
 
+    public List<MediaType> getSuppressedContentTypes() {
+        return suppressedContentTypes;
+    }
+
+    public void setSuppressedContentTypes(final List<MediaType> suppressedContentTypes) {
+        this.suppressedContentTypes = suppressedContentTypes;
+    }
 }

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/MediaTypeVoter.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/MediaTypeVoter.java
@@ -67,7 +67,7 @@ public class MediaTypeVoter {
                 }
             }
 
-            LOGGER.debug("Media type '{}' is excluded, since it is not configured in 'hawaii.logging.allowed-content-types'.", mediaType);
+            LOGGER.debug("Media type '{}' does not match, since it is not configured.", mediaType);
         }
 
         return matches;

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/MediaTypeVoter.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/config/MediaTypeVoter.java
@@ -36,53 +36,41 @@ public class MediaTypeVoter {
     private static final Logger LOGGER = getLogger(MediaTypeVoter.class);
 
     /**
-     * The allowed content types.
+     * The configured content types.
      */
-    private final List<MediaType> allowedContentTypes;
+    private final List<MediaType> contentTypes;
 
-    /**
-     * The constructor.
-     *
-     * @param properties The properties.
-     */
-    public MediaTypeVoter(final HawaiiLoggingConfigurationProperties properties) {
-        allowedContentTypes = properties.getAllowedContentTypes();
-        LOGGER.debug("Allowed content types: '{}'.", allowedContentTypes);
+    private final boolean matchIfEmpty;
+
+    public MediaTypeVoter(final List<MediaType> contentTypes, final boolean matchIfEmpty) {
+        this.contentTypes = contentTypes;
+        this.matchIfEmpty = matchIfEmpty;
+        LOGGER.debug("Configured content types: '{}'.", contentTypes);
     }
 
-    /**
-     * Returns {@code true} if the {@code contentType} is allowed.
-     * @param contentType The content type to check.
-     * @return  {@code true} if the {@code contentType} is allowed.
-     */
-    public boolean mediaTypeAllowed(final String contentType) {
-        return mediaTypeAllowed(parseMediaType(contentType));
+    public boolean mediaTypeMatches(final String contentType) {
+        return mediaTypeMatches(parseMediaType(contentType));
     }
 
-    /**
-     * Returns {@code true} if the {@code mediaType} is allowed.
-     * @param mediaType The media type to check.
-     * @return  {@code true} if the {@code mediaType} is allowed.
-     */
-    public boolean mediaTypeAllowed(final MediaType mediaType) {
-        boolean allowed = false;
+    public boolean mediaTypeMatches(final MediaType mediaType) {
+        boolean matches = false;
 
-        if (mediaType == null || allowedContentTypes == null || allowedContentTypes.isEmpty()) {
-            allowed = true;
+        if (mediaType == null || contentTypes == null || contentTypes.isEmpty()) {
+            matches = matchIfEmpty;
         } else {
 
-            for (final MediaType allowedType : allowedContentTypes) {
+            for (final MediaType allowedType : contentTypes) {
                 final boolean includes = allowedType.includes(mediaType);
                 LOGGER.trace("Type '{}' contains '{}': '{}'.", allowedType, mediaType, includes);
                 if (includes) {
-                    allowed = true;
+                    matches = true;
                 }
             }
 
             LOGGER.debug("Media type '{}' is excluded, since it is not configured in 'hawaii.logging.allowed-content-types'.", mediaType);
         }
 
-        return allowed;
+        return matches;
     }
 
     private MediaType parseMediaType(final String contentType) {

--- a/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
+++ b/hawaii-logging/src/main/java/org/hawaiiframework/logging/http/DefaultHawaiiRequestResponseLogger.java
@@ -98,27 +98,27 @@ public class DefaultHawaiiRequestResponseLogger implements HawaiiRequestResponse
     /**
      * The media type voter to suppress body contents for.
      */
-    private final MediaTypeVoter suppressedMediaTypeVoter;
+    private final MediaTypeVoter bodyExcludedMediaTypeVoter;
 
     /**
      * The constructor.
      *
-     * @param headersLogUtil           The util to use for generating request / response headers log statements.
-     * @param bodyLogUtil              The util to use for generating request / response body log statements.
-     * @param debugLogUtil             The util to use for generating request / response debug log statements.
-     * @param mediaTypeVoter           A media type voter to check for logging.
-     * @param suppressedMediaTypeVoter A media type voter to check to suppress body contents logging.
+     * @param headersLogUtil             The util to use for generating request / response headers log statements.
+     * @param bodyLogUtil                The util to use for generating request / response body log statements.
+     * @param debugLogUtil               The util to use for generating request / response debug log statements.
+     * @param mediaTypeVoter             A media type voter to check for logging.
+     * @param bodyExcludedMediaTypeVoter A media type voter to check to suppress body contents logging.
      */
     public DefaultHawaiiRequestResponseLogger(final HttpRequestResponseHeadersLogUtil headersLogUtil,
             final HttpRequestResponseBodyLogUtil bodyLogUtil,
             final HttpRequestResponseDebugLogUtil debugLogUtil,
             final MediaTypeVoter mediaTypeVoter,
-            final MediaTypeVoter suppressedMediaTypeVoter) {
+            final MediaTypeVoter bodyExcludedMediaTypeVoter) {
         this.bodyLogUtil = bodyLogUtil;
         this.headersLogUtil = headersLogUtil;
         this.debugLogUtil = debugLogUtil;
         this.mediaTypeVoter = mediaTypeVoter;
-        this.suppressedMediaTypeVoter = suppressedMediaTypeVoter;
+        this.bodyExcludedMediaTypeVoter = bodyExcludedMediaTypeVoter;
     }
 
     /**
@@ -205,11 +205,11 @@ public class DefaultHawaiiRequestResponseLogger implements HawaiiRequestResponse
     }
 
     private boolean contentTypeCanBeLogged(final MediaType contentType) {
-        return mediaTypeVoter.mediaTypeMatches(contentType) && !suppressedMediaTypeVoter.mediaTypeMatches(contentType);
+        return mediaTypeVoter.mediaTypeMatches(contentType) && !bodyExcludedMediaTypeVoter.mediaTypeMatches(contentType);
     }
 
     private boolean contentTypeCanBeLogged(final String contentType) {
-        return mediaTypeVoter.mediaTypeMatches(contentType) && !suppressedMediaTypeVoter.mediaTypeMatches(contentType);
+        return mediaTypeVoter.mediaTypeMatches(contentType) && !bodyExcludedMediaTypeVoter.mediaTypeMatches(contentType);
     }
 
     /**

--- a/hawaii-logging/src/test/java/org/hawaiiframework/logging/web/filter/RequestResponseLogFilterTest.java
+++ b/hawaii-logging/src/test/java/org/hawaiiframework/logging/web/filter/RequestResponseLogFilterTest.java
@@ -81,7 +81,7 @@ public class RequestResponseLogFilterTest {
 
         final HawaiiLoggingConfigurationProperties properties = new HawaiiLoggingConfigurationProperties();
         final MediaTypeVoter mediaTypeVoter = new MediaTypeVoter(properties.getAllowedContentTypes(), true);
-        final MediaTypeVoter suppressedMediaTypeVoter = new MediaTypeVoter(properties.getSuppressedContentTypes(), false);
+        final MediaTypeVoter suppressedMediaTypeVoter = new MediaTypeVoter(properties.getBodyExcludedContentTypes(), false);
         final RequestVoter requestVoter = new RequestVoter(properties);
 
         final DefaultHawaiiRequestResponseLogger requestResponseLogger = new DefaultHawaiiRequestResponseLogger(headersLogUtil,

--- a/hawaii-logging/src/test/java/org/hawaiiframework/logging/web/filter/RequestResponseLogFilterTest.java
+++ b/hawaii-logging/src/test/java/org/hawaiiframework/logging/web/filter/RequestResponseLogFilterTest.java
@@ -80,12 +80,15 @@ public class RequestResponseLogFilterTest {
         final HttpRequestResponseDebugLogUtil debugLogUtil = mock(HttpRequestResponseDebugLogUtil.class);
 
         final HawaiiLoggingConfigurationProperties properties = new HawaiiLoggingConfigurationProperties();
-        final MediaTypeVoter mediaTypeVoter = new MediaTypeVoter(properties);
+        final MediaTypeVoter mediaTypeVoter = new MediaTypeVoter(properties.getAllowedContentTypes(), true);
+        final MediaTypeVoter suppressedMediaTypeVoter = new MediaTypeVoter(properties.getSuppressedContentTypes(), false);
         final RequestVoter requestVoter = new RequestVoter(properties);
 
         final DefaultHawaiiRequestResponseLogger requestResponseLogger = new DefaultHawaiiRequestResponseLogger(headersLogUtil,
                 bodyLogUtil,
-                debugLogUtil, mediaTypeVoter);
+                debugLogUtil,
+                mediaTypeVoter,
+                suppressedMediaTypeVoter);
         final FilterVoter filterVoter = new FilterVoter(mediaTypeVoter, requestVoter);
         filter = new RequestResponseLogFilter(requestResponseLogger, filterVoter);
     }

--- a/src/dist/release-notes.md
+++ b/src/dist/release-notes.md
@@ -2,6 +2,7 @@
 
 ### 6.0.0.M3-SNAPSHOT
 * Suppress `form-data/multipart` request logging.
+* Made separate ResponseEntityExceptionHandler for Spring Security exceptions.
 
 ## 6.0.0.M1
 * Use Spring Framework 6.0.0

--- a/src/dist/release-notes.md
+++ b/src/dist/release-notes.md
@@ -3,6 +3,7 @@
 ### 6.0.0.M3-SNAPSHOT
 * Suppress `form-data/multipart` request logging.
 * Made separate ResponseEntityExceptionHandler for Spring Security exceptions.
+* Made separate ResponseEntityExceptionHandler for Jakarta Validation exceptions.
 
 ## 6.0.0.M1
 * Use Spring Framework 6.0.0

--- a/src/dist/release-notes.md
+++ b/src/dist/release-notes.md
@@ -1,5 +1,8 @@
 # Release Notes #
 
+### 6.0.0.M3-SNAPSHOT
+* Suppress `form-data/multipart` request logging.
+
 ## 6.0.0.M1
 * Use Spring Framework 6.0.0
 * Use Spring Boot 3.0.0


### PR DESCRIPTION
Allow suppression of body loggin, configured by default for `multipart/form-data`.
Error handling does not depend on Spring Security, nor Jakarta Validations.